### PR TITLE
feat(storage): add skipBucketCheck option for S3 backend

### DIFF
--- a/etc/chat-api.yaml
+++ b/etc/chat-api.yaml
@@ -15,6 +15,9 @@ Log:
     secretKey: "minioadmin"
     useSSL: false
     region: ""
+    # Skip BucketExists/MakeBucket on startup; set to true when the bucket
+    # is pre-provisioned and credentials lack list/create permissions.
+    skipBucketCheck: false
 
 # Department configuration
 DepartmentApiEndpoint: "http://localhost:1234/work_id?work_id="

--- a/internal/bootstrap/service_context.go
+++ b/internal/bootstrap/service_context.go
@@ -155,12 +155,13 @@ func (svc *ServiceContext) initializeStorage() error {
 		svc.StorageBackend = storage.NewDiskStorage(svc.Config.Log.LogFilePath)
 	case "s3":
 		s3Cfg := storage.S3Config{
-			Endpoint:  svc.Config.Log.S3.Endpoint,
-			Bucket:    svc.Config.Log.S3.Bucket,
-			AccessKey: svc.Config.Log.S3.AccessKey,
-			SecretKey: svc.Config.Log.S3.SecretKey,
-			UseSSL:    svc.Config.Log.S3.UseSSL,
-			Region:    svc.Config.Log.S3.Region,
+			Endpoint:        svc.Config.Log.S3.Endpoint,
+			Bucket:          svc.Config.Log.S3.Bucket,
+			AccessKey:       svc.Config.Log.S3.AccessKey,
+			SecretKey:       svc.Config.Log.S3.SecretKey,
+			UseSSL:          svc.Config.Log.S3.UseSSL,
+			Region:          svc.Config.Log.S3.Region,
+			SkipBucketCheck: svc.Config.Log.S3.SkipBucketCheck,
 		}
 		backend, err := storage.NewS3Storage(s3Cfg)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,12 +87,13 @@ type GenericToolParameter struct {
 
 // LogS3Config holds S3/MinIO storage configuration for log archival
 type LogS3Config struct {
-	Endpoint  string `mapstructure:"endpoint" yaml:"endpoint"`
-	Bucket    string `mapstructure:"bucket" yaml:"bucket"`
-	AccessKey string `mapstructure:"accessKey" yaml:"accessKey"`
-	SecretKey string `mapstructure:"secretKey" yaml:"secretKey"`
-	UseSSL    bool   `mapstructure:"useSSL" yaml:"useSSL"`
-	Region    string `mapstructure:"region" yaml:"region"`
+	Endpoint        string `mapstructure:"endpoint" yaml:"endpoint"`
+	Bucket          string `mapstructure:"bucket" yaml:"bucket"`
+	AccessKey       string `mapstructure:"accessKey" yaml:"accessKey"`
+	SecretKey       string `mapstructure:"secretKey" yaml:"secretKey"`
+	UseSSL          bool   `mapstructure:"useSSL" yaml:"useSSL"`
+	Region          string `mapstructure:"region" yaml:"region"`
+	SkipBucketCheck bool   `mapstructure:"skipBucketCheck" yaml:"skipBucketCheck"`
 }
 
 // LogConfig holds logging configuration

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -18,6 +18,10 @@ type S3Config struct {
 	SecretKey string
 	UseSSL    bool   // Whether to use HTTPS for the connection
 	Region    string // Bucket region, e.g. "us-east-1"; may be empty for MinIO
+	// SkipBucketCheck disables the BucketExists / MakeBucket calls during init.
+	// Useful when the credentials lack s3:ListBucket / s3:CreateBucket but the
+	// bucket is already provisioned out-of-band. Defaults to false (check enabled).
+	SkipBucketCheck bool
 }
 
 // S3Storage implements StorageBackend by writing objects to an S3-compatible
@@ -44,18 +48,20 @@ func NewS3Storage(cfg S3Config) (*S3Storage, error) {
 		return nil, fmt.Errorf("s3 storage: failed to create client: %w", err)
 	}
 
-	ctx := context.Background()
+	if !cfg.SkipBucketCheck {
+		ctx := context.Background()
 
-	exists, err := client.BucketExists(ctx, cfg.Bucket)
-	if err != nil {
-		return nil, fmt.Errorf("s3 storage: failed to check bucket existence: %w", err)
-	}
-	if !exists {
-		err = client.MakeBucket(ctx, cfg.Bucket, minio.MakeBucketOptions{
-			Region: cfg.Region,
-		})
+		exists, err := client.BucketExists(ctx, cfg.Bucket)
 		if err != nil {
-			return nil, fmt.Errorf("s3 storage: failed to create bucket %q: %w", cfg.Bucket, err)
+			return nil, fmt.Errorf("s3 storage: failed to check bucket existence: %w", err)
+		}
+		if !exists {
+			err = client.MakeBucket(ctx, cfg.Bucket, minio.MakeBucketOptions{
+				Region: cfg.Region,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("s3 storage: failed to create bucket %q: %w", cfg.Bucket, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `SkipBucketCheck` field to `S3Config` / `LogS3Config` so the service can boot against a pre-provisioned bucket when credentials lack `s3:ListBucket` / `s3:CreateBucket`
- Wrap the existing `BucketExists` / `MakeBucket` calls in `NewS3Storage` with `if !cfg.SkipBucketCheck`
- Wire the new field through `bootstrap/service_context.go` and document it in `etc/chat-api.yaml`
- Defaults to `false`, so existing deployments keep current behavior

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/storage/... ./internal/config/... ./internal/bootstrap/...` -- all pass
- [ ] Deploy with `Log.s3.skipBucketCheck: true` against a pre-provisioned bucket using read/write-only credentials and confirm startup succeeds without `BucketExists`/`MakeBucket` calls
- [ ] Smoke test default path (`skipBucketCheck: false` or unset) still creates/validates the bucket as before