### PR TITLE
feat: modify downgrade strategy

### DIFF
--- a/internal/logic/chat.go
+++ b/internal/logic/chat.go
@@ -385,7 +385,7 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 				return l.handleStreamError(err, chatLog)
 			}
 
-			retryable := isRetryableAPIError(err)
+			retryable := l.isSameModelRetryableError(err)
 			logger.WarnC(l.ctx, "single-model retry(stream): attempt failed before first token",
 				zap.String("model", l.request.Model),
 				zap.Bool("retryable", retryable),
@@ -452,7 +452,7 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 				return l.handleStreamError(err, chatLog)
 			}
 
-			retryable := isRetryableAPIError(err)
+			retryable := l.isSameModelRetryableError(err)
 			logger.WarnC(l.ctx, "degradation(stream): attempt failed before first token",
 				zap.String("model", modelName),
 				zap.Bool("retryable", retryable),
@@ -478,6 +478,13 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 
 		// If the error is context canceled, stop trying other models
 		if errors.Is(lastErr, context.Canceled) || errors.Is(l.ctx.Err(), context.Canceled) {
+			break
+		}
+		if !l.isDegradationSwitchableError(lastErr) {
+			logger.WarnC(l.ctx, "degradation(stream): non-switchable error, stopping degradation",
+				zap.String("model", modelName),
+				zap.Error(lastErr),
+			)
 			break
 		}
 	}
@@ -1061,7 +1068,7 @@ func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.
 		}
 
 		lastErr = err
-		retryable := isRetryableAPIError(err)
+		retryable := l.isSameModelRetryableError(err)
 		logger.WarnC(l.ctx, "single-model retry: attempt failed",
 			zap.String("model", modelName),
 			zap.Bool("retryable", retryable),
@@ -1134,6 +1141,13 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 			)
 			return nilResp, err
 		}
+		if !l.isDegradationSwitchableError(err) {
+			logger.WarnC(l.ctx, "degradation: non-switchable error, stopping degradation",
+				zap.String("model", modelName),
+				zap.Error(err),
+			)
+			return nilResp, err
+		}
 
 		logger.WarnC(l.ctx, "degradation: model failed, moving to next",
 			zap.String("model", modelName),
@@ -1143,24 +1157,120 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 	return nilResp, lastErr
 }
 
-// isRetryableAPIError returns true when we should retry the same model: timeout/network/5xx
-func isRetryableAPIError(err error) bool {
+// isSameModelRetryableError returns true when the same model may recover by retrying.
+func (l *ChatCompletionLogic) isSameModelRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || errors.Is(l.ctx.Err(), context.Canceled) {
 		return false
 	}
+	if l.isContextLengthError(err) {
+		return false
+	}
+
+	if _, ok := err.(*types.IdleTimeoutError); ok {
+		return true
+	}
+
 	if apiErr, ok := err.(*types.APIError); ok {
-		if apiErr.StatusCode >= http.StatusInternalServerError ||
-			apiErr.Code == types.ErrCodeServerBusy ||
-			apiErr.Code == types.ErrCodeModelServiceUnavailable {
+		switch apiErr.Code {
+		case types.ErrCodeContextExceeded,
+			types.ErrCodeUnauthorized,
+			types.ErrCodeEmptyMessageContent,
+			types.ErrCodeModelUnavailable:
+			return false
+		case types.ErrCodeServerBusy,
+			types.ErrCodeNetworkError:
 			return true
 		}
+
+		switch apiErr.StatusCode {
+		case http.StatusRequestTimeout:
+			return true
+		case http.StatusBadRequest,
+			http.StatusUnauthorized,
+			http.StatusForbidden,
+			http.StatusNotFound,
+			http.StatusTooManyRequests:
+			return false
+		}
+		return apiErr.StatusCode >= http.StatusInternalServerError
+	}
+
+	return true
+}
+
+// isDegradationSwitchableError returns true when auto mode should try the next model.
+func (l *ChatCompletionLogic) isDegradationSwitchableError(err error) bool {
+	if err == nil {
 		return false
 	}
-	// fallback: retry once for non-APIError
+	if errors.Is(err, context.Canceled) || errors.Is(l.ctx.Err(), context.Canceled) {
+		return false
+	}
+	if l.isContextLengthError(err) {
+		return false
+	}
+
+	if _, ok := err.(*types.IdleTimeoutError); ok {
+		return true
+	}
+
+	if apiErr, ok := err.(*types.APIError); ok {
+		switch apiErr.Code {
+		case types.ErrCodeContextExceeded,
+			types.ErrCodeUnauthorized,
+			types.ErrCodeEmptyMessageContent:
+			return false
+		}
+
+		switch apiErr.StatusCode {
+		case http.StatusBadRequest:
+			return isModelCompatibilityError(apiErr)
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return false
+		case http.StatusRequestTimeout, http.StatusTooManyRequests:
+			return true
+		}
+
+		switch apiErr.Code {
+		case types.ErrCodeModelServiceUnavailable,
+			types.ErrCodeModelUnavailable,
+			types.ErrCodeTooManyRequests,
+			types.ErrCodeServerBusy,
+			types.ErrCodeNetworkError,
+			types.ErrCodeInvalidResponseContent:
+			return true
+		}
+
+		return apiErr.StatusCode >= http.StatusInternalServerError
+	}
+
 	return true
+}
+
+func isModelCompatibilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	compatibilitySignals := []string{
+		"reasoning_content",
+		"thinking is enabled",
+		"tool call",
+		"tool_call",
+		"function call",
+		"function_call",
+		"unsupported tool",
+		"unsupported function",
+	}
+	for _, signal := range compatibilitySignals {
+		if strings.Contains(errMsg, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 // handleRawModeStream handles raw mode streaming by directly passing through LLM response
@@ -1229,6 +1339,7 @@ func (l *ChatCompletionLogic) handleRawModeStream(
 				}
 			}
 
+			l.streamCommitted = true
 			if _, err := fmt.Fprintf(l.writer, "%s\n\n", llmResp.ResonseLine); err != nil {
 				return err
 			}
@@ -1239,17 +1350,7 @@ func (l *ChatCompletionLogic) handleRawModeStream(
 	})
 
 	if err != nil {
-		if l.isContextLengthError(err) {
-			logger.ErrorC(ctx, "Input context too long in raw mode", zap.Error(err))
-			lengthErr := types.NewContextTooLongError()
-			l.responseHandler.sendSSEError(ctx, l.writer, lengthErr)
-			chatLog.AddError(types.ErrContextExceeded, lengthErr)
-			return nil
-		}
-
-		l.responseHandler.sendSSEError(ctx, l.writer, err)
-		chatLog.AddError(types.ErrApiError, err)
-		return nil
+		return err
 	}
 
 	// Check if we received any valid content (same logic as completeStreamResponse)
@@ -1259,11 +1360,7 @@ func (l *ChatCompletionLogic) handleRawModeStream(
 	if trimmedContent == "" {
 		logger.WarnC(ctx, "[raw mode] detected invalid or empty response")
 
-		// Send error response
-		noContentErr := types.NewInvaildResponseContentError()
-		l.responseHandler.sendSSEError(ctx, l.writer, noContentErr)
-		chatLog.AddError(types.ErrApiError, noContentErr)
-		return nil
+		return types.NewInvaildResponseContentError()
 	}
 
 	// Record statistics and total latency


### PR DESCRIPTION
1. 重命名 isRetryableAPIError 为 isSameModelRetryableError

  只用于这几个位置：

  single-model retry(stream)
  degradation(stream) 中同一个 model 的 attempt retry
  callModelWithRetry

  语义限定为：当前模型可能只是临时失败，值得再请求一次同一个模型。

  规则：

  true:
  - context 未取消
  - IdleTimeoutError
  - 网络/连接类非 APIError
  - 5xx
  - 408 Request Timeout
  - 429 Too Many Requests，是否 true 取决于你是否希望同模型等待重试

  false:
  - context.Canceled
  - context length exceeded
  - 400
  - 401 / 403
  - 404 model unavailable
  - empty message
  - invalid request / invalid argument

  2. 保留并完善 isDegradationSwitchableError

  只用于 auto 降级循环里决定“当前模型失败后，是否进入下一个模型”。

  规则：

  true:
  - IdleTimeoutError
  - 5xx
  - 408 / 429
  - model_services_unavailable
  - model_unavailable
  - server_busy
  - network_interrupt
  - invalid_response_content
  - 当前模型协议/能力不兼容类 400，例如 thinking/reasoning_content/tool call 格式问题

  false:
  - context.Canceled
  - context length exceeded
  - unauthorized / forbidden
  - empty message
  - 明确用户请求参数非法

  3. 对 400 做细分，不要一刀切

  types.NewHTTPStatusError(400, body) 现在会包装成 model_services_unavailable，这会掩盖真实语义。短期可以在 isDegradationSwitchableError 里按 message 判断：

  func isModelCompatibilityError(err error) bool {
      msg := strings.ToLower(err.Error())
      return strings.Contains(msg, "reasoning_content") ||
          strings.Contains(msg, "thinking is enabled") ||
          strings.Contains(msg, "tool call") ||
          strings.Contains(msg, "function call")
  }

  然后：

  case http.StatusBadRequest:
      return isModelCompatibilityError(apiErr)

  长期更好是在 NewHTTPStatusError 里解析上游 body，把 OpenAI 风格的 invalid_request_error、message、param 保留下来，避免只能字符串匹配。

  4. 调用点调整

  流式 auto 内层 attempt：

  retryable := isSameModelRetryableError(err)
  if retryable && attempt < maxRetryCount {
      retry same model
  }

  流式 auto 外层 model loop：

  if !l.isDegradationSwitchableError(lastErr) {
      break
  }
  continue // next model

  非流式同理：

  callModelWithRetry -> 只负责同模型重试
  callWithDegradation -> 负责是否切下一个模型