### PR TITLE
feat: auto mode support vip

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,16 +205,19 @@ router:
   #       enabled: true
   #       priority: 1           # Lower number = higher priority (0-999)
   #       weight: 5             # Weight for load balancing within same priority (1-100)
+  #       minVipLevel: 1        # Minimum VIP level required in auto mode; 0 means all users
   #
   #     - modelName: "claude-3-opus"
   #       enabled: true
   #       priority: 1           # Same priority as gpt-4
   #       weight: 3             # Lower weight than gpt-4
+  #       minVipLevel: 0
   #
   #     - modelName: "gpt-3.5-turbo"
   #       enabled: true
   #       priority: 2           # Lower priority, used when priority 1 fails
   #       weight: 10
+  #       minVipLevel: 0
   #
   #   fallbackModelName: "gpt-3.5-turbo"
   #
@@ -265,8 +268,10 @@ router:
     - Simple, cost-effective strategy without semantic analysis; selects models by priority (lower number = higher priority, range 0-999).
     - Uses smooth weighted round-robin algorithm for load balancing within same priority group.
     - Configuration fields:
-      - `candidates`: List of candidate models with `modelName`, `enabled`, `priority` (0-999), and `weight` (1-100).
-      - `fallbackModelName`: Fallback model when all candidates fail.
+      - `candidates`: List of candidate models with `modelName`, `enabled`, `priority` (0-999), `weight` (1-100), and optional `minVipLevel` (default 0).
+      - `minVipLevel`: Minimum VIP level required for AUTO mode to see this candidate. `0` or omitted means visible to all users. VIP-only candidates are also excluded from AUTO degradation for users that do not meet the requirement.
+      - `fallbackModelName`: Fallback model when all candidates fail. For priority AUTO routing, the fallback must be present in `candidates` (enforced at config load — startup fails otherwise). It is appended to the degradation chain only when also visible to the current user; otherwise a warning is logged and it is skipped at runtime.
+      - **Degradation ordering**: within the same `priority`, candidates are ordered by `weight` descending; when weights tie, the original `candidates` configuration order is preserved (stable sort).
       - Timeout and retry settings (same as semantic routing):
         - `idleTimeoutMs`: Single idle timeout (ms). Default 180000ms (180s).
         - `totalIdleTimeoutMs`: Total idle timeout budget (ms). Default 180000ms (180s).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,16 +205,19 @@ router:
         enabled: true
         priority: 1           # 优先级（数字越小优先级越高，范围 0-999）
         weight: 5             # 权重（同优先级内的负载均衡，范围 1-100）
+        minVipLevel: 1        # AUTO 模式可见所需的最低 VIP 等级；0 表示所有用户可见
 
       - modelName: "claude-3-opus"
         enabled: true
         priority: 1           # 与 gpt-4 同优先级
         weight: 3             # 权重比 gpt-4 低
+        minVipLevel: 0
 
       - modelName: "gpt-3.5-turbo"
         enabled: true
         priority: 2           # 优先级较低，仅在优先级 1 失败时使用
         weight: 10
+        minVipLevel: 0
 
     fallbackModelName: "gpt-3.5-turbo"
 
@@ -265,8 +268,10 @@ router:
     - 简单、低成本的策略，无需语义分析；根据优先级选择模型（数字越小优先级越高，范围 0-999）
     - 使用平滑加权轮询算法在同优先级组内实现负载均衡
     - 配置字段：
-      - `candidates`：候选模型列表，包含 `modelName`、`enabled`、`priority`（0-999）和 `weight`（1-100）
-      - `fallbackModelName`：所有候选模型失败时的回退模型
+      - `candidates`：候选模型列表，包含 `modelName`、`enabled`、`priority`（0-999）、`weight`（1-100）以及可选的 `minVipLevel`（默认 0）
+      - `minVipLevel`：AUTO 模式下可见该候选模型所需的最低 VIP 等级。`0` 或未配置表示所有用户可见。不满足要求的 VIP 模型不会进入 AUTO 首选或降级链路。
+      - `fallbackModelName`：所有候选模型失败时的回退模型。priority AUTO 路由中，fallback 必须存在于 `candidates`（配置加载时强校验，缺失则启动失败）；运行时仅当 fallback 对当前用户可见时才追加到降级链，否则记录 warn 日志并跳过。
+      - **降级顺序契约**：同 `priority` 内按 `weight` 降序排序；`weight` 相同时保持 `candidates` 配置的原始顺序（稳定排序）。
       - 超时和重试配置（与语义路由相同）：
         - `idleTimeoutMs`：单次空闲超时（毫秒），默认 180000ms (180s)
         - `totalIdleTimeoutMs`：总空闲超时预算（毫秒），默认 180000ms (180s)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -327,10 +327,11 @@ type PriorityConfig struct {
 
 // PriorityCandidate defines a candidate model with priority and weight
 type PriorityCandidate struct {
-	ModelName string `mapstructure:"modelName" yaml:"modelName"`
-	Enabled   bool   `mapstructure:"enabled" yaml:"enabled"`
-	Priority  int    `mapstructure:"priority" yaml:"priority"` // Lower number = higher priority
-	Weight    int    `mapstructure:"weight" yaml:"weight"`     // Weight for round-robin within same priority
+	ModelName   string `mapstructure:"modelName" yaml:"modelName"`
+	Enabled     bool   `mapstructure:"enabled" yaml:"enabled"`
+	Priority    int    `mapstructure:"priority" yaml:"priority"`
+	Weight      int    `mapstructure:"weight" yaml:"weight"`
+	MinVipLevel int    `mapstructure:"minVipLevel" yaml:"minVipLevel"`
 }
 
 // AgentConfig holds configuration for a specific agent

--- a/internal/logic/chat.go
+++ b/internal/logic/chat.go
@@ -173,42 +173,52 @@ func (l *ChatCompletionLogic) logCompletion(chatLog *model.ChatLog) {
 	}
 }
 
-// ChatCompletion handles chat completion requests
-func (l *ChatCompletionLogic) ChatCompletion() (resp *types.ChatCompletionResponse, err error) {
-	// Router: select model before prompt processing & LLM client creation
+func (l *ChatCompletionLogic) resolveAutoRouter() error {
+	if l.svcCtx.Config.Router == nil || !l.svcCtx.Config.Router.Enabled || !strings.EqualFold(l.request.Model, "auto") {
+		return nil
+	}
 	origModel := l.request.Model
-	if l.svcCtx.Config.Router != nil && l.svcCtx.Config.Router.Enabled && strings.EqualFold(l.request.Model, "auto") {
-		logger.InfoC(l.ctx, "semantic router: auto mode routing start",
-			zap.String("strategy", l.svcCtx.Config.Router.Strategy),
-		)
-		// Use cached strategy instance to maintain state across requests (e.g., round-robin weights)
-		if runner := l.getOrCreateRouterStrategy(); runner != nil {
-			selected, current, ordered, rerr := runner.Run(l.ctx, l.svcCtx, l.headers, l.request)
-			if rerr == nil && selected != "" {
-				l.request.Model = selected
-				l.orderedModels = ordered
-				// mark original model via request header for upstream
-				if l.headers != nil && strings.EqualFold(origModel, "auto") {
-					l.headers.Set(types.HeaderOriginalModel, "Auto")
-				}
-				if l.writer != nil {
-					l.writer.Header().Set(types.HeaderSelectLLm, selected)
-					if current != "" {
-						safe := sanitizeHeaderValue(current)
-						if safe != "" {
-							encodedCur := base64.StdEncoding.EncodeToString([]byte(safe))
-							if encodedCur != "" {
-								l.writer.Header().Set(types.HeaderUserInput, encodedCur)
-							}
-						}
+	logger.InfoC(l.ctx, "semantic router: auto mode routing start",
+		zap.String("strategy", l.svcCtx.Config.Router.Strategy),
+	)
+	runner := l.getOrCreateRouterStrategy()
+	if runner == nil {
+		return fmt.Errorf("auto router: strategy %q is unknown or has invalid configuration", l.svcCtx.Config.Router.Strategy)
+	}
+	selected, current, ordered, rerr := runner.Run(l.ctx, l.svcCtx, l.headers, l.request)
+	if rerr != nil {
+		return fmt.Errorf("auto router: %w", rerr)
+	}
+	if selected != "" {
+		l.request.Model = selected
+		l.orderedModels = ordered
+		if l.headers != nil && strings.EqualFold(origModel, "auto") {
+			l.headers.Set(types.HeaderOriginalModel, "Auto")
+		}
+		if l.writer != nil {
+			l.writer.Header().Set(types.HeaderSelectLLm, selected)
+			if current != "" {
+				safe := sanitizeHeaderValue(current)
+				if safe != "" {
+					encodedCur := base64.StdEncoding.EncodeToString([]byte(safe))
+					if encodedCur != "" {
+						l.writer.Header().Set(types.HeaderUserInput, encodedCur)
 					}
 				}
-				logger.InfoC(l.ctx, "semantic router: auto mode routing selected",
-					zap.String("selected_model", selected),
-					zap.Int("user_input_len", len([]byte(current))),
-				)
 			}
 		}
+		logger.InfoC(l.ctx, "semantic router: auto mode routing selected",
+			zap.String("selected_model", selected),
+			zap.Int("user_input_len", len([]byte(current))),
+		)
+	}
+	return nil
+}
+
+// ChatCompletion handles chat completion requests
+func (l *ChatCompletionLogic) ChatCompletion() (resp *types.ChatCompletionResponse, err error) {
+	if err := l.resolveAutoRouter(); err != nil {
+		return nil, err
 	}
 
 	chatLog, processedPrompt, err := l.processRequest()
@@ -296,40 +306,8 @@ func (l *ChatCompletionLogic) getRetryConfig() (maxRetryCount int, retryInterval
 
 // ChatCompletionStream handles streaming chat completion with SSE
 func (l *ChatCompletionLogic) ChatCompletionStream() error {
-	// Router: select model before streaming LLM client creation
-	origModel := l.request.Model
-	if l.svcCtx.Config.Router != nil && l.svcCtx.Config.Router.Enabled && strings.EqualFold(l.request.Model, "auto") {
-		logger.InfoC(l.ctx, "semantic router: auto mode routing start",
-			zap.String("strategy", l.svcCtx.Config.Router.Strategy),
-		)
-		// Use cached strategy instance to maintain state across requests (e.g., round-robin weights)
-		if runner := l.getOrCreateRouterStrategy(); runner != nil {
-			selected, current, ordered, rerr := runner.Run(l.ctx, l.svcCtx, l.headers, l.request)
-			if rerr == nil && selected != "" {
-				l.request.Model = selected
-				l.orderedModels = ordered
-				// mark original model via request header for upstream
-				if l.headers != nil && strings.EqualFold(origModel, "auto") {
-					l.headers.Set(types.HeaderOriginalModel, "Auto")
-				}
-				if l.writer != nil {
-					l.writer.Header().Set(types.HeaderSelectLLm, selected)
-					if current != "" {
-						safe := sanitizeHeaderValue(current)
-						if safe != "" {
-							encodedCur := base64.StdEncoding.EncodeToString([]byte(safe))
-							if encodedCur != "" {
-								l.writer.Header().Set(types.HeaderUserInput, encodedCur)
-							}
-						}
-					}
-				}
-				logger.InfoC(l.ctx, "semantic router: auto mode routing selected",
-					zap.String("selected_model", selected),
-					zap.Int("user_input_len", len([]byte(current))),
-				)
-			}
-		}
+	if err := l.resolveAutoRouter(); err != nil {
+		return err
 	}
 
 	chatLog, processedPrompt, err := l.processRequest()

--- a/internal/logic/chat_auto_router_test.go
+++ b/internal/logic/chat_auto_router_test.go
@@ -1,0 +1,487 @@
+package logic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/zgsm-ai/chat-rag/internal/bootstrap"
+	"github.com/zgsm-ai/chat-rag/internal/config"
+	"github.com/zgsm-ai/chat-rag/internal/model"
+	"github.com/zgsm-ai/chat-rag/internal/service/mocks"
+	"github.com/zgsm-ai/chat-rag/internal/types"
+)
+
+func setupAutoRouterTestSvcCtx(t *testing.T, routerCfg *config.RouterConfig) (*bootstrap.ServiceContext, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+	loggerMock := mocks.NewMockLoggerInterface(ctrl)
+	metricsMock := mocks.NewMockMetricsInterface(ctrl)
+	loggerMock.EXPECT().LogAsync(gomock.Any(), gomock.Any()).AnyTimes()
+	metricsMock.EXPECT().GetRegistry().Return(prometheus.NewRegistry()).AnyTimes()
+
+	svcCtx := &bootstrap.ServiceContext{
+		Config: config.Config{
+			FromNacos: config.FromNacos{
+				Router: routerCfg,
+			},
+		},
+		LoggerService:  loggerMock,
+		MetricsService: metricsMock,
+	}
+	return svcCtx, ctrl
+}
+
+func autoRouterRequest() *types.ChatCompletionRequest {
+	return &types.ChatCompletionRequest{
+		Model: "auto",
+		LLMRequestParams: types.LLMRequestParams{
+			Messages: []types.Message{
+				{Role: types.RoleUser, Content: "hello"},
+			},
+		},
+	}
+}
+
+func autoRouterIdentityNoVip() *model.Identity {
+	return &model.Identity{
+		UserName: "test-user",
+		UserInfo: &model.UserInfo{
+			Vip:  0,
+			Name: "test-user",
+		},
+	}
+}
+
+func autoRouterCtxWithIdentity(identity *model.Identity) context.Context {
+	return context.WithValue(context.Background(), model.IdentityContextKey, identity)
+}
+
+func TestAutoRouter_ChatCompletion_NoVisibleCandidates_ReturnsError(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "vip-only-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 5},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	resp, err := logic.ChatCompletion()
+	assert.Error(t, err, "ChatCompletion should return an error when no visible candidates")
+	assert.Nil(t, resp, "response should be nil on auto router error")
+	assert.True(t,
+		strings.Contains(err.Error(), "no visible candidates") || strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'no visible candidates' or 'auto router', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletion_NilRunner_ReturnsError(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "unknown-strategy",
+		Priority: config.PriorityConfig{},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	resp, err := logic.ChatCompletion()
+	assert.Error(t, err, "ChatCompletion should return error when runner is nil for auto model")
+	assert.Nil(t, resp)
+	assert.True(t,
+		strings.Contains(err.Error(), "unknown or has invalid configuration") ||
+			strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'unknown or has invalid configuration', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletion_InvalidPriorityConfig_NilRunner(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	resp, err := logic.ChatCompletion()
+	assert.Error(t, err, "ChatCompletion should return error when priority config is invalid (runner nil)")
+	assert.Nil(t, resp)
+	assert.True(t,
+		strings.Contains(err.Error(), "unknown or has invalid configuration"),
+		fmt.Sprintf("error should mention 'unknown or has invalid configuration', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletionStream_NoVisibleCandidates_ReturnsError(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "vip-only-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 5},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	err := logic.ChatCompletionStream()
+	assert.Error(t, err, "ChatCompletionStream should return an error when no visible candidates")
+	assert.True(t,
+		strings.Contains(err.Error(), "no visible candidates") || strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'no visible candidates' or 'auto router', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletionStream_NilRunner_ReturnsError(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "unknown-strategy",
+		Priority: config.PriorityConfig{},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	err := logic.ChatCompletionStream()
+	assert.Error(t, err, "ChatCompletionStream should return error when runner is nil for auto model")
+	assert.True(t,
+		strings.Contains(err.Error(), "unknown or has invalid configuration") ||
+			strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'unknown or has invalid configuration', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletionStream_InvalidPriorityConfig_NilRunner(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	err := logic.ChatCompletionStream()
+	assert.Error(t, err, "ChatCompletionStream should return error when priority config is invalid (runner nil)")
+	assert.True(t,
+		strings.Contains(err.Error(), "unknown or has invalid configuration"),
+		fmt.Sprintf("error should mention 'unknown or has invalid configuration', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletion_RunError_ReturnsOriginalError(t *testing.T) {
+	strategy := &mockFailingStrategy{err: fmt.Errorf("no visible candidates configured for current user")}
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	svcCtx.SetRouterStrategy(strategy)
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	resp, err := logic.ChatCompletion()
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t,
+		strings.Contains(err.Error(), "no visible candidates") || strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'no visible candidates' or 'auto router', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ChatCompletionStream_RunError_ReturnsOriginalError(t *testing.T) {
+	strategy := &mockFailingStrategy{err: fmt.Errorf("no visible candidates configured for current user")}
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	svcCtx.SetRouterStrategy(strategy)
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	err := logic.ChatCompletionStream()
+	assert.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "no visible candidates") || strings.Contains(err.Error(), "auto router"),
+		fmt.Sprintf("error should mention 'no visible candidates' or 'auto router', got: %v", err),
+	)
+}
+
+func TestAutoRouter_ResolveAutoRouter_Success_UpdatesModel(t *testing.T) {
+	strategy := &mockSuccessStrategy{
+		selected: "model-a",
+		ordered:  []string{"model-a", "model-b"},
+	}
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	svcCtx.SetRouterStrategy(strategy)
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	assert.Equal(t, "auto", logic.request.Model)
+	assert.Nil(t, logic.orderedModels)
+
+	err := logic.resolveAutoRouter()
+	assert.NoError(t, err, "resolveAutoRouter should not error on successful routing")
+	assert.Equal(t, "model-a", logic.request.Model,
+		"model should have been updated by successful routing")
+	assert.Equal(t, []string{"model-a", "model-b"}, logic.orderedModels)
+}
+
+func TestAutoRouter_ResolveAutoRouter_Bypass_NilRouter(t *testing.T) {
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, nil)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	req.Model = "auto"
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	assert.Equal(t, "auto", logic.request.Model)
+	err := logic.resolveAutoRouter()
+	assert.NoError(t, err, "resolveAutoRouter should return nil when Router config is nil")
+	assert.Equal(t, "auto", logic.request.Model,
+		"model should remain unchanged when Router config is nil")
+	assert.Nil(t, logic.orderedModels,
+		"orderedModels should remain nil when Router config is nil")
+	assert.Empty(t, writer.Header().Get(types.HeaderSelectLLm),
+		"x-select-llm header should not be set when Router config is nil")
+}
+
+func TestAutoRouter_ResolveAutoRouter_Bypass_RouterDisabled(t *testing.T) {
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, &config.RouterConfig{
+		Enabled:  false,
+		Strategy: "priority",
+	})
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	req.Model = "auto"
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	assert.Equal(t, "auto", logic.request.Model)
+	err := logic.resolveAutoRouter()
+	assert.NoError(t, err, "resolveAutoRouter should return nil when Router is disabled")
+	assert.Equal(t, "auto", logic.request.Model,
+		"model should remain unchanged when Router is disabled")
+	assert.Nil(t, logic.orderedModels,
+		"orderedModels should remain nil when Router is disabled")
+	assert.Empty(t, writer.Header().Get(types.HeaderSelectLLm),
+		"x-select-llm header should not be set when Router is disabled")
+}
+
+func TestAutoRouter_ResolveAutoRouter_Bypass_ModelNotAuto(t *testing.T) {
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	req := autoRouterRequest()
+	req.Model = "gpt-4"
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	assert.Equal(t, "gpt-4", logic.request.Model)
+	err := logic.resolveAutoRouter()
+	assert.NoError(t, err, "resolveAutoRouter should return nil when model is not auto")
+	assert.Equal(t, "gpt-4", logic.request.Model,
+		"model should remain unchanged when model is not auto")
+	assert.Nil(t, logic.orderedModels,
+		"orderedModels should remain nil when model is not auto")
+	assert.Empty(t, writer.Header().Get(types.HeaderSelectLLm),
+		"x-select-llm header should not be set when model is not auto")
+}
+
+func TestAutoRouter_ResolveAutoRouter_EmptySelect_NoChange(t *testing.T) {
+	strategy := &mockSuccessStrategy{
+		selected: "",
+		ordered:  nil,
+	}
+	routerCfg := &config.RouterConfig{
+		Enabled:  true,
+		Strategy: "priority",
+		Priority: config.PriorityConfig{
+			Candidates: []config.PriorityCandidate{
+				{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+			},
+		},
+	}
+
+	svcCtx, ctrl := setupAutoRouterTestSvcCtx(t, routerCfg)
+	defer ctrl.Finish()
+
+	svcCtx.SetRouterStrategy(strategy)
+
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	ctx := autoRouterCtxWithIdentity(identity)
+	writer := &mockResponseWriter{}
+
+	logic := NewChatCompletionLogic(ctx, svcCtx, req, writer, &hdr, identity)
+
+	assert.Equal(t, "auto", logic.request.Model)
+	assert.Nil(t, logic.orderedModels)
+
+	err := logic.resolveAutoRouter()
+	assert.NoError(t, err, "resolveAutoRouter should not error when strategy returns empty select")
+	assert.Equal(t, "auto", logic.request.Model,
+		"model should remain unchanged when selected is empty")
+	assert.Nil(t, logic.orderedModels,
+		"orderedModels should remain nil when selected is empty")
+	assert.Empty(t, hdr.Get(types.HeaderOriginalModel),
+		"x-original-model header should not be set when selected is empty")
+	assert.Empty(t, writer.Header().Get(types.HeaderSelectLLm),
+		"x-select-llm header should not be set when selected is empty")
+}
+
+type mockFailingStrategy struct {
+	err error
+}
+
+func (m *mockFailingStrategy) Name() string { return "mock-failing" }
+func (m *mockFailingStrategy) Run(_ context.Context, _ *bootstrap.ServiceContext, _ *http.Header, _ *types.ChatCompletionRequest) (string, string, []string, error) {
+	return "", "", nil, m.err
+}
+
+type mockSuccessStrategy struct {
+	selected string
+	ordered  []string
+}
+
+func (m *mockSuccessStrategy) Name() string { return "mock-success" }
+func (m *mockSuccessStrategy) Run(_ context.Context, _ *bootstrap.ServiceContext, _ *http.Header, _ *types.ChatCompletionRequest) (string, string, []string, error) {
+	return m.selected, "", m.ordered, nil
+}

--- a/internal/router/strategies/priority/priority.go
+++ b/internal/router/strategies/priority/priority.go
@@ -23,7 +23,6 @@ type Strategy struct {
 	cfg            config.PriorityConfig
 	priorityGroups map[int]*PriorityGroup
 	mu             sync.RWMutex
-	lowestPriority int // Track the highest priority (lowest number)
 }
 
 // New creates a new priority strategy instance
@@ -35,7 +34,6 @@ func New(cfg config.PriorityConfig) (*Strategy, error) {
 	s := &Strategy{
 		cfg:            cfg,
 		priorityGroups: make(map[int]*PriorityGroup),
-		lowestPriority: 999,
 	}
 
 	// Initialize priority groups from config
@@ -117,11 +115,6 @@ func (s *Strategy) initializePriorityGroups() error {
 			minVipLevel: candidate.MinVipLevel,
 		}
 		group.addModel(model)
-
-		// Track lowest priority number (highest priority)
-		if candidate.Priority < s.lowestPriority {
-			s.lowestPriority = candidate.Priority
-		}
 	}
 
 	if len(s.priorityGroups) == 0 {
@@ -129,15 +122,6 @@ func (s *Strategy) initializePriorityGroups() error {
 	}
 
 	return nil
-}
-
-// filterEnabledCandidates returns all enabled candidates
-func (s *Strategy) filterEnabledCandidates() []*ModelCandidate {
-	candidates := make([]*ModelCandidate, 0)
-	for _, group := range s.priorityGroups {
-		candidates = append(candidates, group.getModels()...)
-	}
-	return candidates
 }
 
 // buildOrderedCandidates builds an ordered list of candidates for degradation

--- a/internal/router/strategies/priority/priority.go
+++ b/internal/router/strategies/priority/priority.go
@@ -8,10 +8,12 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/zgsm-ai/chat-rag/internal/bootstrap"
 	"github.com/zgsm-ai/chat-rag/internal/config"
 	"github.com/zgsm-ai/chat-rag/internal/logger"
+	"github.com/zgsm-ai/chat-rag/internal/model"
 	"github.com/zgsm-ai/chat-rag/internal/types"
 	"go.uber.org/zap"
 )
@@ -60,7 +62,6 @@ func (s *Strategy) Run(
 		return "", "", nil, nil
 	}
 
-	// Only trigger when request model is "auto"
 	if !strings.EqualFold(req.Model, "auto") {
 		return "", "", nil, nil
 	}
@@ -68,38 +69,26 @@ func (s *Strategy) Run(
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// 1. Filter enabled candidates
-	enabledCandidates := s.filterEnabledCandidates()
-	if len(enabledCandidates) == 0 {
-		logger.WarnC(ctx, "priority router: no enabled candidates found")
-		if s.cfg.FallbackModelName != "" {
-			return s.cfg.FallbackModelName, "", []string{s.cfg.FallbackModelName}, nil
-		}
-		return "", "", nil, errors.New("no enabled candidates and no fallback configured")
+	identity, _ := model.GetIdentityFromContext(ctx)
+	selection := s.visibleSelectionFor(identity, time.Now())
+	if len(selection.allVisible) == 0 {
+		logger.WarnC(ctx, "priority router: no visible candidates found")
+		return "", "", nil, errors.New("no visible candidates configured for current user")
+	}
+	if selection.selectedGroup == nil {
+		logger.ErrorC(ctx, "priority router: visible priority group not found")
+		return "", "", nil, errors.New("visible priority group not found")
 	}
 
-	// 2. Select the highest priority group (lowest priority number)
-	highestPriorityGroup := s.priorityGroups[s.lowestPriority]
-	if highestPriorityGroup == nil {
-		logger.ErrorC(ctx, "priority router: highest priority group not found",
-			zap.Int("priority", s.lowestPriority))
-		if s.cfg.FallbackModelName != "" {
-			return s.cfg.FallbackModelName, "", []string{s.cfg.FallbackModelName}, nil
-		}
-		return "", "", nil, errors.New("priority group not found")
-	}
-
-	// 3. Select model using round-robin within the priority group
-	selectedModel := highestPriorityGroup.selectModelByRoundRobin()
+	selectedModel := selection.selectedGroup.selectVisibleModelByRoundRobin(selection.selectedVisible)
 
 	logger.InfoC(ctx, "priority router: model selected",
 		zap.String("selectedModel", selectedModel),
-		zap.Int("priority", s.lowestPriority),
-		zap.Int("groupSize", len(highestPriorityGroup.models)),
+		zap.Int("priority", selection.selectedPriority),
+		zap.Int("visibleGroupSize", len(selection.selectedVisible)),
 	)
 
-	// 4. Build ordered candidates list (selectedModel first, then by priority and weight)
-	orderedCandidates := s.buildOrderedCandidates(selectedModel)
+	orderedCandidates := s.buildOrderedCandidates(selectedModel, selection.allVisible)
 
 	return selectedModel, "", orderedCandidates, nil
 }
@@ -151,51 +140,92 @@ func (s *Strategy) filterEnabledCandidates() []*ModelCandidate {
 }
 
 // buildOrderedCandidates builds an ordered list of candidates for degradation
-// The selectedModel is always first, followed by other models sorted by priority (ascending)
+// The selectedModel is always first, followed by other visible models sorted by priority (ascending)
 // and weight (descending) within the same priority
-func (s *Strategy) buildOrderedCandidates(selectedModel string) []string {
+func (s *Strategy) buildOrderedCandidates(selectedModel string, visibleCandidates []*ModelCandidate) []string {
 	result := []string{selectedModel}
 
-	// Get all priority levels sorted (ascending order - lower number = higher priority)
+	ordered := append([]*ModelCandidate(nil), visibleCandidates...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].priority == ordered[j].priority {
+			return ordered[i].weight > ordered[j].weight
+		}
+		return ordered[i].priority < ordered[j].priority
+	})
+
+	for _, candidate := range ordered {
+		if candidate.modelName != selectedModel {
+			result = append(result, candidate.modelName)
+		}
+	}
+
+	return result
+}
+
+func isCandidateVisible(candidate *ModelCandidate, identity *model.Identity, now time.Time) bool {
+	if candidate == nil {
+		return false
+	}
+	required := candidate.minVipLevel
+	if required == 0 {
+		return true
+	}
+	if identity == nil || identity.UserInfo == nil {
+		return false
+	}
+	user := identity.UserInfo
+	hasVipLevel := user.Vip >= required
+	isVipUnexpired := user.VipExpire == nil || now.Before(*user.VipExpire)
+	return hasVipLevel && isVipUnexpired
+}
+
+func filterVisibleModels(models []*ModelCandidate, identity *model.Identity, now time.Time) []*ModelCandidate {
+	visible := make([]*ModelCandidate, 0, len(models))
+	for _, candidate := range models {
+		if isCandidateVisible(candidate, identity, now) {
+			visible = append(visible, candidate)
+		}
+	}
+	return visible
+}
+
+type visibleSelection struct {
+	selectedPriority int
+	selectedGroup    *PriorityGroup
+	selectedVisible  []*ModelCandidate
+	allVisible       []*ModelCandidate
+}
+
+func (s *Strategy) visibleSelectionFor(identity *model.Identity, now time.Time) visibleSelection {
 	priorities := make([]int, 0, len(s.priorityGroups))
 	for priority := range s.priorityGroups {
 		priorities = append(priorities, priority)
 	}
 	sort.Ints(priorities)
 
-	// Build ordered list
+	selection := visibleSelection{
+		selectedPriority: -1,
+		allVisible:       make([]*ModelCandidate, 0),
+	}
+
 	for _, priority := range priorities {
 		group := s.priorityGroups[priority]
-		models := group.getModels()
-
-		// Sort by weight descending within same priority
-		sort.Slice(models, func(i, j int) bool {
-			return models[i].weight > models[j].weight
-		})
-
-		for _, model := range models {
-			// Skip selectedModel (already first)
-			if model.modelName != selectedModel {
-				result = append(result, model.modelName)
-			}
+		if group == nil {
+			continue
 		}
+		visible := filterVisibleModels(group.getModels(), identity, now)
+		if len(visible) == 0 {
+			continue
+		}
+		if selection.selectedGroup == nil {
+			selection.selectedPriority = priority
+			selection.selectedGroup = group
+			selection.selectedVisible = visible
+		}
+		selection.allVisible = append(selection.allVisible, visible...)
 	}
 
-	// Append fallback model if not already in list
-	if s.cfg.FallbackModelName != "" {
-		found := false
-		for _, m := range result {
-			if m == s.cfg.FallbackModelName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			result = append(result, s.cfg.FallbackModelName)
-		}
-	}
-
-	return result
+	return selection
 }
 
 // validateConfig validates the priority configuration

--- a/internal/router/strategies/priority/priority.go
+++ b/internal/router/strategies/priority/priority.go
@@ -89,6 +89,7 @@ func (s *Strategy) Run(
 	)
 
 	orderedCandidates := s.buildOrderedCandidates(selectedModel, selection.allVisible)
+	orderedCandidates = s.appendVisibleFallback(ctx, orderedCandidates, selection.allVisible)
 
 	return selectedModel, "", orderedCandidates, nil
 }
@@ -160,6 +161,44 @@ func (s *Strategy) buildOrderedCandidates(selectedModel string, visibleCandidate
 	}
 
 	return result
+}
+
+func containsModel(models []string, modelName string) bool {
+	for _, m := range models {
+		if m == modelName {
+			return true
+		}
+	}
+	return false
+}
+
+func findCandidateByName(candidates []*ModelCandidate, modelName string) *ModelCandidate {
+	for _, c := range candidates {
+		if c.modelName == modelName {
+			return c
+		}
+	}
+	return nil
+}
+
+func (s *Strategy) appendVisibleFallback(
+	ctx context.Context,
+	ordered []string,
+	visibleCandidates []*ModelCandidate,
+) []string {
+	if s.cfg.FallbackModelName == "" {
+		return ordered
+	}
+	if containsModel(ordered, s.cfg.FallbackModelName) {
+		return ordered
+	}
+	fallback := findCandidateByName(visibleCandidates, s.cfg.FallbackModelName)
+	if fallback == nil {
+		logger.WarnC(ctx, "priority router: fallback model is not visible to current user",
+			zap.String("fallbackModelName", s.cfg.FallbackModelName))
+		return ordered
+	}
+	return append(ordered, fallback.modelName)
 }
 
 func isCandidateVisible(candidate *ModelCandidate, identity *model.Identity, now time.Time) bool {

--- a/internal/router/strategies/priority/priority.go
+++ b/internal/router/strategies/priority/priority.go
@@ -178,11 +178,25 @@ func (s *Strategy) appendVisibleFallback(
 	}
 	fallback := findCandidateByName(visibleCandidates, s.cfg.FallbackModelName)
 	if fallback == nil {
-		logger.WarnC(ctx, "priority router: fallback model is not visible to current user",
-			zap.String("fallbackModelName", s.cfg.FallbackModelName))
+		if !s.isCandidateDeclared(s.cfg.FallbackModelName) {
+			logger.WarnC(ctx, "priority router: fallback model is not declared in candidates",
+				zap.String("fallbackModelName", s.cfg.FallbackModelName))
+		} else {
+			logger.WarnC(ctx, "priority router: fallback model is not visible to current user",
+				zap.String("fallbackModelName", s.cfg.FallbackModelName))
+		}
 		return ordered
 	}
 	return append(ordered, fallback.modelName)
+}
+
+func (s *Strategy) isCandidateDeclared(modelName string) bool {
+	for _, c := range s.cfg.Candidates {
+		if c.ModelName == modelName {
+			return true
+		}
+	}
+	return false
 }
 
 func isCandidateVisible(candidate *ModelCandidate, identity *model.Identity, now time.Time) bool {
@@ -278,19 +292,6 @@ func validateConfig(cfg config.PriorityConfig) error {
 
 	if !hasEnabled {
 		return errors.New("at least one candidate must be enabled")
-	}
-
-	if cfg.FallbackModelName != "" {
-		found := false
-		for _, candidate := range cfg.Candidates {
-			if candidate.ModelName == cfg.FallbackModelName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("fallbackModelName %q must be present in candidates", cfg.FallbackModelName)
-		}
 	}
 
 	return nil

--- a/internal/router/strategies/priority/priority.go
+++ b/internal/router/strategies/priority/priority.go
@@ -18,10 +18,10 @@ import (
 
 // Strategy implements the priority-based round-robin routing strategy
 type Strategy struct {
-	cfg             config.PriorityConfig
-	priorityGroups  map[int]*PriorityGroup
-	mu              sync.RWMutex
-	lowestPriority  int // Track the highest priority (lowest number)
+	cfg            config.PriorityConfig
+	priorityGroups map[int]*PriorityGroup
+	mu             sync.RWMutex
+	lowestPriority int // Track the highest priority (lowest number)
 }
 
 // New creates a new priority strategy instance
@@ -120,10 +120,11 @@ func (s *Strategy) initializePriorityGroups() error {
 
 		// Add model to group
 		model := &ModelCandidate{
-			modelName: candidate.ModelName,
-			priority:  candidate.Priority,
-			weight:    candidate.Weight,
-			enabled:   candidate.Enabled,
+			modelName:   candidate.ModelName,
+			priority:    candidate.Priority,
+			weight:      candidate.Weight,
+			enabled:     candidate.Enabled,
+			minVipLevel: candidate.MinVipLevel,
 		}
 		group.addModel(model)
 
@@ -214,6 +215,9 @@ func validateConfig(cfg config.PriorityConfig) error {
 		if candidate.Weight < 1 || candidate.Weight > 100 {
 			return fmt.Errorf("weight must be between 1 and 100 for model %s", candidate.ModelName)
 		}
+		if candidate.MinVipLevel < 0 {
+			return fmt.Errorf("minVipLevel must be >= 0 for model %s", candidate.ModelName)
+		}
 		if candidate.Enabled {
 			hasEnabled = true
 		}
@@ -221,6 +225,19 @@ func validateConfig(cfg config.PriorityConfig) error {
 
 	if !hasEnabled {
 		return errors.New("at least one candidate must be enabled")
+	}
+
+	if cfg.FallbackModelName != "" {
+		found := false
+		for _, candidate := range cfg.Candidates {
+			if candidate.ModelName == cfg.FallbackModelName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("fallbackModelName %q must be present in candidates", cfg.FallbackModelName)
+		}
 	}
 
 	return nil

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -201,6 +201,32 @@ func TestPriorityRouterAppendsVisibleFallbackWhenMissingFromOrder(t *testing.T) 
 	}
 }
 
+func TestAppendVisibleFallbackAppendsWhenMissingFromOrder(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "primary", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 0},
+			{ModelName: "fallback", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+		FallbackModelName: "fallback",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	ordered := []string{"primary"}
+	visible := []*ModelCandidate{
+		{modelName: "primary", priority: 100, weight: 1, enabled: true, minVipLevel: 0},
+		{modelName: "fallback", priority: 200, weight: 1, enabled: true, minVipLevel: 0},
+	}
+
+	result := strategy.appendVisibleFallback(context.Background(), ordered, visible)
+
+	want := []string{"primary", "fallback"}
+	if !reflect.DeepEqual(result, want) {
+		t.Fatalf("result = %#v, want %#v", result, want)
+	}
+}
+
 func TestPriorityRouterDoesNotDuplicateVisibleFallback(t *testing.T) {
 	strategy, err := New(config.PriorityConfig{
 		Candidates: []config.PriorityCandidate{

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -1,0 +1,73 @@
+package priority
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zgsm-ai/chat-rag/internal/config"
+	"github.com/zgsm-ai/chat-rag/internal/model"
+	"github.com/zgsm-ai/chat-rag/internal/types"
+)
+
+func TestValidateConfigRejectsNegativeMinVipLevel(t *testing.T) {
+	err := validateConfig(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{
+				ModelName:   "vip-model",
+				Enabled:     true,
+				Priority:    100,
+				Weight:      1,
+				MinVipLevel: -1,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected negative minVipLevel to be rejected")
+	}
+	if !strings.Contains(err.Error(), "minVipLevel must be >= 0") {
+		t.Fatalf("expected minVipLevel validation error, got %v", err)
+	}
+}
+
+func testAutoRequest() *types.ChatCompletionRequest {
+	req := &types.ChatCompletionRequest{
+		Model: "auto",
+	}
+	req.Messages = []types.Message{
+		{Role: types.RoleUser, Content: "hello"},
+	}
+	return req
+}
+
+func testIdentity(vip int, expire *time.Time) *model.Identity {
+	return &model.Identity{
+		UserName: "test-user",
+		UserInfo: &model.UserInfo{
+			Name:      "test-user",
+			Vip:       vip,
+			VipExpire: expire,
+		},
+	}
+}
+
+func contextWithIdentity(identity *model.Identity) context.Context {
+	return context.WithValue(context.Background(), model.IdentityContextKey, identity)
+}
+
+func TestValidateConfigRejectsFallbackMissingFromCandidates(t *testing.T) {
+	err := validateConfig(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "normal-model", Enabled: true, Priority: 100, Weight: 1},
+		},
+		FallbackModelName: "missing-fallback",
+	})
+	if err == nil {
+		t.Fatal("expected missing fallback to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be present in candidates") {
+		t.Fatalf("expected fallback validation error, got %v", err)
+	}
+}

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -2,6 +2,7 @@ package priority
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -69,5 +70,81 @@ func TestValidateConfigRejectsFallbackMissingFromCandidates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must be present in candidates") {
 		t.Fatalf("expected fallback validation error, got %v", err)
+	}
+}
+
+func TestPriorityRouterOrdinaryUserSkipsVipOnlyCandidates(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "vip-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 1},
+			{ModelName: "normal-model", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "normal-model" {
+		t.Fatalf("selected = %q, want normal-model", selected)
+	}
+	want := []string{"normal-model"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}
+
+func TestPriorityRouterVipUserCanUseVipOnlyCandidates(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "vip-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 1},
+			{ModelName: "normal-model", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(contextWithIdentity(testIdentity(1, nil)), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "vip-model" {
+		t.Fatalf("selected = %q, want vip-model", selected)
+	}
+	want := []string{"vip-model", "normal-model"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}
+
+func TestPriorityRouterExpiredVipUserSkipsVipOnlyCandidates(t *testing.T) {
+	expired := time.Now().Add(-time.Minute)
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "vip-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 1},
+			{ModelName: "normal-model", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(contextWithIdentity(testIdentity(1, &expired)), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "normal-model" {
+		t.Fatalf("selected = %q, want normal-model", selected)
+	}
+	want := []string{"normal-model"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
 	}
 }

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -58,18 +58,28 @@ func contextWithIdentity(identity *model.Identity) context.Context {
 	return context.WithValue(context.Background(), model.IdentityContextKey, identity)
 }
 
-func TestValidateConfigRejectsFallbackMissingFromCandidates(t *testing.T) {
-	err := validateConfig(config.PriorityConfig{
+func TestFallbackNotInCandidatesNewSucceedsRunSkips(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
 		Candidates: []config.PriorityCandidate{
 			{ModelName: "normal-model", Enabled: true, Priority: 100, Weight: 1},
 		},
 		FallbackModelName: "missing-fallback",
 	})
-	if err == nil {
-		t.Fatal("expected missing fallback to be rejected")
+	if err != nil {
+		t.Fatalf("New should succeed when fallback is not in candidates, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "must be present in candidates") {
-		t.Fatalf("expected fallback validation error, got %v", err)
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "normal-model" {
+		t.Fatalf("selected = %q, want normal-model", selected)
+	}
+	want := []string{"normal-model"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
 	}
 }
 
@@ -276,5 +286,45 @@ func TestPriorityRouterReturnsErrorWhenNoCandidateVisible(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no visible candidates") {
 		t.Fatalf("error = %v, want no visible candidates", err)
+	}
+}
+
+func TestOmittedMinVipLevelIsVisibleToOrdinaryUser(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "model-a", Enabled: true, Priority: 100, Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "model-a" {
+		t.Fatalf("selected = %q, want model-a", selected)
+	}
+	want := []string{"model-a"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}
+
+func TestIsCandidateDeclaredReturnsTrueForDisabledCandidate(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "enabled-model", Enabled: true, Priority: 100, Weight: 1},
+			{ModelName: "disabled-fallback", Enabled: false, Priority: 200, Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if !strategy.isCandidateDeclared("disabled-fallback") {
+		t.Fatal("isCandidateDeclared(disabled-fallback) = false, want true")
 	}
 }

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -148,3 +148,81 @@ func TestPriorityRouterExpiredVipUserSkipsVipOnlyCandidates(t *testing.T) {
 		t.Fatalf("ordered = %#v, want %#v", ordered, want)
 	}
 }
+
+func TestPriorityRouterSkipsInvisibleFallback(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "normal-model", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+			{ModelName: "vip-fallback", Enabled: true, Priority: 300, Weight: 1, MinVipLevel: 1},
+		},
+		FallbackModelName: "vip-fallback",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "normal-model" {
+		t.Fatalf("selected = %q, want normal-model", selected)
+	}
+	want := []string{"normal-model"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}
+
+func TestPriorityRouterAppendsVisibleFallbackWhenMissingFromOrder(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "primary", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 0},
+			{ModelName: "fallback", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+		FallbackModelName: "fallback",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "primary" {
+		t.Fatalf("selected = %q, want primary", selected)
+	}
+	want := []string{"primary", "fallback"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}
+
+func TestPriorityRouterDoesNotDuplicateVisibleFallback(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "fallback", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 0},
+			{ModelName: "secondary", Enabled: true, Priority: 200, Weight: 1, MinVipLevel: 0},
+		},
+		FallbackModelName: "fallback",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if selected != "fallback" {
+		t.Fatalf("selected = %q, want fallback", selected)
+	}
+	want := []string{"fallback", "secondary"}
+	if !reflect.DeepEqual(ordered, want) {
+		t.Fatalf("ordered = %#v, want %#v", ordered, want)
+	}
+}

--- a/internal/router/strategies/priority/priority_vip_test.go
+++ b/internal/router/strategies/priority/priority_vip_test.go
@@ -252,3 +252,29 @@ func TestPriorityRouterDoesNotDuplicateVisibleFallback(t *testing.T) {
 		t.Fatalf("ordered = %#v, want %#v", ordered, want)
 	}
 }
+
+func TestPriorityRouterReturnsErrorWhenNoCandidateVisible(t *testing.T) {
+	strategy, err := New(config.PriorityConfig{
+		Candidates: []config.PriorityCandidate{
+			{ModelName: "vip-model", Enabled: true, Priority: 100, Weight: 1, MinVipLevel: 1},
+		},
+		FallbackModelName: "vip-model",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	selected, _, ordered, err := strategy.Run(context.Background(), nil, nil, testAutoRequest())
+	if err == nil {
+		t.Fatal("expected error when no candidates are visible")
+	}
+	if selected != "" {
+		t.Fatalf("selected = %q, want empty", selected)
+	}
+	if ordered != nil {
+		t.Fatalf("ordered = %#v, want nil", ordered)
+	}
+	if !strings.Contains(err.Error(), "no visible candidates") {
+		t.Fatalf("error = %v, want no visible candidates", err)
+	}
+}

--- a/internal/router/strategies/priority/round_robin.go
+++ b/internal/router/strategies/priority/round_robin.go
@@ -40,9 +40,9 @@ func (pg *PriorityGroup) addModel(model *ModelCandidate) {
 // This method is thread-safe and implements the algorithm from the design document:
 // 1. Each model has a configured weight and a current weight (initially 0)
 // 2. For each selection:
-//    - Add configured weight to current weight for all models
-//    - Select the model with the highest current weight
-//    - Subtract total weight from the selected model's current weight
+//   - Add configured weight to current weight for all models
+//   - Select the model with the highest current weight
+//   - Subtract total weight from the selected model's current weight
 func (pg *PriorityGroup) selectModelByRoundRobin() string {
 	// Optimization: If only one model, return directly without locking
 	// This provides zero-lock overhead for single-model scenarios
@@ -83,4 +83,16 @@ func (pg *PriorityGroup) selectModelByRoundRobin() string {
 // getModels returns all models in the group sorted by weight (descending)
 func (pg *PriorityGroup) getModels() []*ModelCandidate {
 	return pg.models
+}
+
+// selectVisibleModelByRoundRobin is a temporary adapter that selects from visible candidates only.
+// Task 3 will replace this with per-visible-set isolated round-robin state.
+func (pg *PriorityGroup) selectVisibleModelByRoundRobin(visible []*ModelCandidate) string {
+	if len(visible) == 0 {
+		return ""
+	}
+	if len(visible) == 1 {
+		return visible[0].modelName
+	}
+	return visible[0].modelName
 }

--- a/internal/router/strategies/priority/round_robin.go
+++ b/internal/router/strategies/priority/round_robin.go
@@ -6,10 +6,11 @@ import (
 
 // ModelCandidate represents a candidate model with its configuration
 type ModelCandidate struct {
-	modelName string
-	priority  int
-	weight    int
-	enabled   bool
+	modelName   string
+	priority    int
+	weight      int
+	enabled     bool
+	minVipLevel int
 }
 
 // PriorityGroup represents a group of models with the same priority level

--- a/internal/router/strategies/priority/round_robin.go
+++ b/internal/router/strategies/priority/round_robin.go
@@ -1,10 +1,11 @@
 package priority
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 )
 
-// ModelCandidate represents a candidate model with its configuration
 type ModelCandidate struct {
 	modelName   string
 	priority    int
@@ -13,80 +14,33 @@ type ModelCandidate struct {
 	minVipLevel int
 }
 
-// PriorityGroup represents a group of models with the same priority level
 type PriorityGroup struct {
-	priority       int
-	models         []*ModelCandidate
-	currentWeights []int
-	mu             sync.Mutex
+	priority int
+	models   []*ModelCandidate
+	states   map[string][]int
+	mu       sync.Mutex
 }
 
-// newPriorityGroup creates a new priority group
 func newPriorityGroup(priority int) *PriorityGroup {
 	return &PriorityGroup{
-		priority:       priority,
-		models:         make([]*ModelCandidate, 0),
-		currentWeights: make([]int, 0),
+		priority: priority,
+		models:   make([]*ModelCandidate, 0),
+		states:   make(map[string][]int),
 	}
 }
 
-// addModel adds a model to the priority group
 func (pg *PriorityGroup) addModel(model *ModelCandidate) {
 	pg.models = append(pg.models, model)
-	pg.currentWeights = append(pg.currentWeights, 0)
 }
 
-// selectModelByRoundRobin selects a model using smooth weighted round-robin algorithm
-// This method is thread-safe and implements the algorithm from the design document:
-// 1. Each model has a configured weight and a current weight (initially 0)
-// 2. For each selection:
-//   - Add configured weight to current weight for all models
-//   - Select the model with the highest current weight
-//   - Subtract total weight from the selected model's current weight
-func (pg *PriorityGroup) selectModelByRoundRobin() string {
-	// Optimization: If only one model, return directly without locking
-	// This provides zero-lock overhead for single-model scenarios
-	if len(pg.models) == 1 {
-		return pg.models[0].modelName
+func buildVisibleSetKey(visible []*ModelCandidate) string {
+	var sb strings.Builder
+	for _, model := range visible {
+		fmt.Fprintf(&sb, "%d:%s", len(model.modelName), model.modelName)
 	}
-
-	pg.mu.Lock()
-	defer pg.mu.Unlock()
-
-	// Calculate total weight
-	totalWeight := 0
-	for _, model := range pg.models {
-		totalWeight += model.weight
-	}
-
-	// Find the model with the maximum current weight after adding configured weights
-	maxWeight := -1
-	selectedIdx := -1
-
-	for i, model := range pg.models {
-		// Add configured weight to current weight
-		pg.currentWeights[i] += model.weight
-
-		// Find the model with maximum current weight
-		if pg.currentWeights[i] > maxWeight {
-			maxWeight = pg.currentWeights[i]
-			selectedIdx = i
-		}
-	}
-
-	// Subtract total weight from the selected model's current weight
-	pg.currentWeights[selectedIdx] -= totalWeight
-
-	return pg.models[selectedIdx].modelName
+	return sb.String()
 }
 
-// getModels returns all models in the group sorted by weight (descending)
-func (pg *PriorityGroup) getModels() []*ModelCandidate {
-	return pg.models
-}
-
-// selectVisibleModelByRoundRobin is a temporary adapter that selects from visible candidates only.
-// Task 3 will replace this with per-visible-set isolated round-robin state.
 func (pg *PriorityGroup) selectVisibleModelByRoundRobin(visible []*ModelCandidate) string {
 	if len(visible) == 0 {
 		return ""
@@ -94,5 +48,38 @@ func (pg *PriorityGroup) selectVisibleModelByRoundRobin(visible []*ModelCandidat
 	if len(visible) == 1 {
 		return visible[0].modelName
 	}
-	return visible[0].modelName
+
+	key := buildVisibleSetKey(visible)
+
+	pg.mu.Lock()
+	defer pg.mu.Unlock()
+
+	weights := pg.states[key]
+	if len(weights) != len(visible) {
+		weights = make([]int, len(visible))
+	}
+
+	totalWeight := 0
+	for _, model := range visible {
+		totalWeight += model.weight
+	}
+
+	maxWeight := -1
+	selectedIdx := 0
+	for i, model := range visible {
+		weights[i] += model.weight
+		if weights[i] > maxWeight {
+			maxWeight = weights[i]
+			selectedIdx = i
+		}
+	}
+
+	weights[selectedIdx] -= totalWeight
+	pg.states[key] = weights
+
+	return visible[selectedIdx].modelName
+}
+
+func (pg *PriorityGroup) getModels() []*ModelCandidate {
+	return pg.models
 }

--- a/internal/router/strategies/priority/round_robin_vip_test.go
+++ b/internal/router/strategies/priority/round_robin_vip_test.go
@@ -40,6 +40,39 @@ func TestBuildVisibleSetKeyUsesLengthPrefixEncoding(t *testing.T) {
 	}
 }
 
+func TestWeightedRoundRobinDistributesByWeight(t *testing.T) {
+	group := newPriorityGroup(100)
+	group.addModel(&ModelCandidate{modelName: "heavy", priority: 100, weight: 5})
+	group.addModel(&ModelCandidate{modelName: "light", priority: 100, weight: 1})
+
+	visible := []*ModelCandidate{group.models[0], group.models[1]}
+
+	counts := map[string]int{}
+	for i := 0; i < 6; i++ {
+		selected := group.selectVisibleModelByRoundRobin(visible)
+		counts[selected]++
+	}
+
+	if counts["heavy"] != 5 {
+		t.Fatalf("heavy count = %d, want 5 (over 6 selections)", counts["heavy"])
+	}
+	if counts["light"] != 1 {
+		t.Fatalf("light count = %d, want 1 (over 6 selections)", counts["light"])
+	}
+}
+
+func TestBuildVisibleSetKeyDiffersByInputOrder(t *testing.T) {
+	a := &ModelCandidate{modelName: "alpha"}
+	b := &ModelCandidate{modelName: "beta"}
+
+	keyAB := buildVisibleSetKey([]*ModelCandidate{a, b})
+	keyBA := buildVisibleSetKey([]*ModelCandidate{b, a})
+
+	if keyAB == keyBA {
+		t.Fatalf("expected distinct keys for different input orders, got %q == %q", keyAB, keyBA)
+	}
+}
+
 func TestBuildVisibleSetKeyAvoidsSeparatorCollision(t *testing.T) {
 	one := buildVisibleSetKey([]*ModelCandidate{{modelName: "a|b"}})
 	two := buildVisibleSetKey([]*ModelCandidate{{modelName: "a"}, {modelName: "b"}})

--- a/internal/router/strategies/priority/round_robin_vip_test.go
+++ b/internal/router/strategies/priority/round_robin_vip_test.go
@@ -1,0 +1,49 @@
+package priority
+
+import "testing"
+
+func TestPriorityGroupRoundRobinStateIsolatedByVisibleSet(t *testing.T) {
+	group := newPriorityGroup(100)
+	group.addModel(&ModelCandidate{modelName: "normal-a", priority: 100, weight: 1})
+	group.addModel(&ModelCandidate{modelName: "normal-b", priority: 100, weight: 1})
+	group.addModel(&ModelCandidate{modelName: "vip-a", priority: 100, weight: 1, minVipLevel: 1})
+
+	ordinaryVisible := []*ModelCandidate{group.models[0], group.models[1]}
+	vipVisible := []*ModelCandidate{group.models[0], group.models[1], group.models[2]}
+
+	if got := group.selectVisibleModelByRoundRobin(ordinaryVisible); got != "normal-a" {
+		t.Fatalf("ordinary first selection = %q, want normal-a", got)
+	}
+	if got := group.selectVisibleModelByRoundRobin(vipVisible); got != "normal-a" {
+		t.Fatalf("vip first selection = %q, want normal-a with independent state", got)
+	}
+	if got := group.selectVisibleModelByRoundRobin(ordinaryVisible); got != "normal-b" {
+		t.Fatalf("ordinary second selection = %q, want normal-b", got)
+	}
+	if got := group.selectVisibleModelByRoundRobin(vipVisible); got != "normal-b" {
+		t.Fatalf("vip second selection = %q, want normal-b", got)
+	}
+	if got := group.selectVisibleModelByRoundRobin(vipVisible); got != "vip-a" {
+		t.Fatalf("vip third selection = %q, want vip-a", got)
+	}
+}
+
+func TestBuildVisibleSetKeyUsesLengthPrefixEncoding(t *testing.T) {
+	visible := []*ModelCandidate{
+		{modelName: "normal-a"},
+		{modelName: "vip-a"},
+	}
+
+	want := "8:normal-a5:vip-a"
+	if got := buildVisibleSetKey(visible); got != want {
+		t.Fatalf("key = %q, want %q", got, want)
+	}
+}
+
+func TestBuildVisibleSetKeyAvoidsSeparatorCollision(t *testing.T) {
+	one := buildVisibleSetKey([]*ModelCandidate{{modelName: "a|b"}})
+	two := buildVisibleSetKey([]*ModelCandidate{{modelName: "a"}, {modelName: "b"}})
+	if one == two {
+		t.Fatalf("expected distinct keys, got %q == %q", one, two)
+	}
+}


### PR DESCRIPTION
# AUTO 模式 VIP 模型路由实现计划

**目标：** 在 priority AUTO 模式下，让 VIP 用户可以进入 VIP 模型候选池，同时普通用户在 AUTO 模式下看不到 VIP 模型。

**架构：** 在 priority router 的候选模型上增加 `minVipLevel` 元数据，并在每次 AUTO 路由运行时按当前用户身份过滤可见候选。保留现有 priority strategy 的缓存实例，但将 smooth weighted round-robin 状态按“当前可见候选集合”隔离，避免普通用户和 VIP 用户共享轮询权重状态。

**技术栈：** Go、Viper mapstructure/YAML 配置结构、现有 `internal/router/strategies/priority` 路由、Go 单元测试。

---

## 范围

本计划只修改 `model: "auto"` 且 `router.strategy: priority` 的行为。

不拦截直接指定模型的请求。如果非 VIP 用户发送 `{"model": "VIP-Model"}`，仍沿用当前非 AUTO 路径。

## 术语澄清

本计划中出现的 `priority` 一律指 **router strategy 名称**（`router.strategy: priority`）以及候选模型在 strategy 内的优先级排序（`PriorityCandidate.Priority` / `PriorityGroup.priority`）。它与 CONTEXT.md "Flagged Ambiguities" 中提到的 **VIP priority**（即请求上的 `priority` 字段）无关：VIP Model 可见性由 `minVipLevel` 控制，不由请求 priority 控制。

## 已确认的领域规则

- `router.priority.candidates[].minVipLevel` 控制 AUTO 模式下候选模型的可见性。
- `minVipLevel` 默认值为 `0`，表示所有用户可见。
- `minVipLevel > 0` 的候选模型，仅当 `identity.UserInfo.Vip >= minVipLevel` 时可见。
- VIP 过期逻辑沿用现有规则：`VipExpire == nil` 表示未过期；否则必须满足 `time.Now().Before(*VipExpire)`。
- 没有 identity、没有 `UserInfo`、`Vip == 0`、VIP 已过期的用户，在 VIP 模型可见性上都按普通用户处理。
- AUTO priority 选择模型时，如果更高优先级组内的模型对当前用户全部不可见，必须跳过该组。
- AUTO 降级链只能包含当前用户可见的候选模型。
- `fallbackModelName` 必须存在于 `router.priority.candidates`。这是 **配置不变量**：`validateConfig` 在配置加载阶段强校验，缺失时直接拒绝启动，而不是运行时 warn 跳过。这样才能保证后续按 `minVipLevel` 评估可见性时一定能找到候选。
- fallback 对当前用户可见且尚未出现在降级链中时，可以追加到降级链末尾。
- fallback **存在于 candidates 但对当前用户不可见**时，跳过并记录 warn 日志（普通用户面对 VIP 专属 fallback 的运行时分支）。
- 过滤后没有任何可见候选时，返回错误，不使用不可见 fallback 兜底。
- **同 priority 内的 degradation 顺序契约**：按 `weight` 降序排序（`sort.SliceStable`）；`weight` 相同时保持 `candidates` 配置中的输入顺序。该顺序是稳定的、可预期的，后续实现者不得改成非稳定排序。

## 文件结构

- 修改 `internal/config/config.go`
  - 给 `PriorityCandidate` 增加 `MinVipLevel` 字段。

- 修改 `internal/router/strategies/priority/round_robin.go`
  - 给内部 `ModelCandidate` 增加 `minVipLevel`。
  - 将单一 `currentWeights` 改成 `states map[string][]int`。
  - 增加按可见候选集合隔离的 smooth weighted round-robin 选择逻辑。

- 修改 `internal/router/strategies/priority/priority.go`
  - 初始化时加载 `minVipLevel`。
  - 从 `context.Context` 读取 `model.Identity`。
  - 每次请求按当前用户过滤可见候选。
  - 动态选择当前用户可见的最高优先级组。
  - 只基于可见候选构建降级链。
  - 实现 fallback 可见性规则（运行时仅处理"可见性"分支，不再处理"不存在于 candidates"分支——后者由配置校验拦截）。
  - 校验 `minVipLevel >= 0`。
  - 校验 `fallbackModelName != ""` 时必须存在于 `candidates`。

- 新建 `internal/router/strategies/priority/priority_vip_test.go`
  - 覆盖普通用户、VIP 用户、过期 VIP 用户、fallback 行为和配置校验。

- 新建 `internal/router/strategies/priority/round_robin_vip_test.go`
  - 覆盖不同可见候选集合的 round-robin 状态隔离。

- 修改 `README.md` 和 `README.zh-CN.md`
  - 记录 priority router 的 `minVipLevel` 配置。
