### PR TITLE
feat: auto degradation trace

### DIFF
--- a/internal/logic/chat.go
+++ b/internal/logic/chat.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.uber.org/zap"
 
@@ -39,6 +41,10 @@ type ChatCompletionLogic struct {
 	orderedModels   []string
 	streamCommitted bool
 	originalModel   string
+
+	degradationTrace     []model.DegradationEvent
+	degradationTraceSeq  int
+	degradationTraceFull bool
 }
 
 func NewChatCompletionLogic(
@@ -65,6 +71,11 @@ func NewChatCompletionLogic(
 const (
 	MaxToolCallDepth    = 6
 	MaxToolResultLength = 100_000
+)
+
+const (
+	maxDegradationTraceEvents = 64
+	maxDegradationErrorBytes  = 512
 )
 
 // processRequest handles common request processing logic
@@ -168,6 +179,9 @@ func (l *ChatCompletionLogic) updateChatLog(chatLog *model.ChatLog, processedPro
 func (l *ChatCompletionLogic) logCompletion(chatLog *model.ChatLog) {
 	chatLog.Latency.TotalLatency = time.Since(chatLog.Timestamp).Milliseconds()
 	chatLog.Params.RoutedModel = l.request.Model
+	if len(l.degradationTrace) > 0 {
+		chatLog.DegradationTrace = append([]model.DegradationEvent(nil), l.degradationTrace...)
+	}
 	if l.svcCtx.LoggerService != nil {
 		l.svcCtx.LoggerService.LogAsync(chatLog, l.headers)
 	}
@@ -393,7 +407,17 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 
 	maxRetryCount, retryInterval, _, _ := l.getRetryConfig()
 	var lastErr error
-	for _, modelName := range models {
+	if len(models) > 0 {
+		l.appendDegradationEvent(model.DegradationEvent{
+			Event:         model.DegradationEventStarted,
+			Model:         models[0],
+			ModelIndex:    0,
+			OrderedModels: append([]string(nil), models...),
+			MaxRetries:    maxRetryCount,
+			Reason:        "auto_mode_stream",
+		})
+	}
+	for modelIndex, modelName := range models {
 		// Update header immediately when switching to a different model in auto mode
 		if l.writer != nil {
 			l.writer.Header().Set(types.HeaderSelectLLm, modelName)
@@ -419,14 +443,40 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 			l.request.Model = modelName
 			l.streamCommitted = false
 
+			attemptStart := time.Now()
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventAttemptStarted,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Attempt:    attempt + 1,
+				MaxRetries: maxRetryCount,
+			})
+
 			err = l.handleStreamingWithTools(l.ctx, llmClient, flusher, chatLog, MaxToolCallDepth, idleTracker)
 			if err == nil {
+				l.appendDegradationEvent(model.DegradationEvent{
+					Event:      model.DegradationEventModelSucceeded,
+					Model:      modelName,
+					ModelIndex: modelIndex,
+					Attempt:    attempt + 1,
+					MaxRetries: maxRetryCount,
+					ElapsedMs:  time.Since(attemptStart).Milliseconds(),
+					Reason:     "model_call_succeeded",
+				})
 				return nil
 			}
 
 			lastErr = err
 			if l.streamCommitted {
 				// Already started streaming; report error to client and stop
+				l.appendDegradationEvent(model.DegradationEvent{
+					Event:      model.DegradationEventStopped,
+					Model:      modelName,
+					ModelIndex: modelIndex,
+					Attempt:    attempt + 1,
+					MaxRetries: maxRetryCount,
+					Reason:     "stream_committed",
+				})
 				return l.handleStreamError(err, chatLog)
 			}
 
@@ -436,6 +486,24 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 				zap.Bool("retryable", retryable),
 				zap.Error(err),
 			)
+			switchable := l.isDegradationSwitchableError(err)
+			statusCode, errorCode, errorType, errorMessage, compatibilitySignal := degradationErrorFields(err)
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:               model.DegradationEventAttemptFailed,
+				Model:               modelName,
+				ModelIndex:          modelIndex,
+				Attempt:             attempt + 1,
+				MaxRetries:          maxRetryCount,
+				Retryable:           &retryable,
+				Switchable:          &switchable,
+				StatusCode:          statusCode,
+				ErrorCode:           errorCode,
+				ErrorType:           errorType,
+				ErrorMessage:        errorMessage,
+				ElapsedMs:           time.Since(attemptStart).Milliseconds(),
+				Reason:              "stream_failed_before_first_token",
+				CompatibilitySignal: compatibilitySignal,
+			})
 			if retryable && attempt < maxRetryCount {
 				// Check if we have enough idle budget remaining for retry
 				remainingIdleBudget := idleTracker.Remaining()
@@ -445,8 +513,24 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 						zap.String("model", modelName),
 						zap.Duration("remainingIdleBudget", remainingIdleBudget),
 						zap.Duration("minRequiredBudget", minRequiredBudget))
+					l.appendDegradationEvent(model.DegradationEvent{
+						Event:      model.DegradationEventRetrySkippedInsufficientBudget,
+						Model:      modelName,
+						ModelIndex: modelIndex,
+						Attempt:    attempt + 1,
+						MaxRetries: maxRetryCount,
+						Reason:     "insufficient_idle_budget",
+					})
 					break
 				}
+				l.appendDegradationEvent(model.DegradationEvent{
+					Event:      model.DegradationEventRetryScheduled,
+					Model:      modelName,
+					ModelIndex: modelIndex,
+					Attempt:    attempt + 1,
+					MaxRetries: maxRetryCount,
+					Reason:     "retryable_error",
+				})
 				time.Sleep(retryInterval)
 				attempt++
 				continue
@@ -456,6 +540,12 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 
 		// If the error is context canceled, stop trying other models
 		if errors.Is(lastErr, context.Canceled) || errors.Is(l.ctx.Err(), context.Canceled) {
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventStopped,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Reason:     "context_canceled",
+			})
 			break
 		}
 		if !l.isDegradationSwitchableError(lastErr) {
@@ -463,7 +553,23 @@ func (l *ChatCompletionLogic) ChatCompletionStream() error {
 				zap.String("model", modelName),
 				zap.Error(lastErr),
 			)
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventStopped,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Reason:     "non_switchable_error",
+			})
 			break
+		}
+		if modelIndex+1 < len(models) {
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:         model.DegradationEventModelSwitch,
+				PreviousModel: modelName,
+				Model:         models[modelIndex+1],
+				ModelIndex:    modelIndex + 1,
+				OrderedModels: append([]string(nil), models...),
+				Reason:        "previous_model_failed",
+			})
 		}
 	}
 	return l.handleStreamError(lastErr, chatLog)
@@ -1001,6 +1107,15 @@ func (l *ChatCompletionLogic) isContextLengthError(err error) bool {
 		strings.Contains(errMsg, "Input text is too long")
 }
 
+func (l *ChatCompletionLogic) degradationModelIndex(modelName string) int {
+	for i, ordered := range l.orderedModels {
+		if ordered == modelName {
+			return i
+		}
+	}
+	return -1
+}
+
 func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.LLMRequestParams, idleTrackerOpt ...*timeout.IdleTracker) (types.ChatCompletionResponse, error) {
 	nilResp := types.ChatCompletionResponse{}
 
@@ -1031,6 +1146,16 @@ func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.
 			zap.Int("maxRetries", maxRetryCount),
 		)
 
+		modelIndex := l.degradationModelIndex(modelName)
+		attemptStart := time.Now()
+		l.appendDegradationEvent(model.DegradationEvent{
+			Event:      model.DegradationEventAttemptStarted,
+			Model:      modelName,
+			ModelIndex: modelIndex,
+			Attempt:    attempt + 1,
+			MaxRetries: maxRetryCount,
+		})
+
 		// Use the shared idle tracker instead of creating a new one
 		timerCtx, timerCancel, idleTimer := timeout.NewIdleTimer(l.ctx, idleTimeout, sharedTracker)
 		resp, err := llmClient.ChatLLMWithMessagesRaw(timerCtx, params, idleTimer)
@@ -1042,6 +1167,15 @@ func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.
 				l.writer.Header().Set(types.HeaderSelectLLm, modelName)
 			}
 			logger.InfoC(l.ctx, "single-model retry: model succeeded", zap.String("model", modelName))
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventModelSucceeded,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Attempt:    attempt + 1,
+				MaxRetries: maxRetryCount,
+				ElapsedMs:  time.Since(attemptStart).Milliseconds(),
+				Reason:     "model_call_succeeded",
+			})
 			return resp, nil
 		}
 
@@ -1053,6 +1187,25 @@ func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.
 			zap.Error(err),
 		)
 
+		switchable := l.isDegradationSwitchableError(err)
+		statusCode, errorCode, errorType, errorMessage, compatibilitySignal := degradationErrorFields(err)
+		l.appendDegradationEvent(model.DegradationEvent{
+			Event:               model.DegradationEventAttemptFailed,
+			Model:               modelName,
+			ModelIndex:          modelIndex,
+			Attempt:             attempt + 1,
+			MaxRetries:          maxRetryCount,
+			Retryable:           &retryable,
+			Switchable:          &switchable,
+			StatusCode:          statusCode,
+			ErrorCode:           errorCode,
+			ErrorType:           errorType,
+			ErrorMessage:        errorMessage,
+			ElapsedMs:           time.Since(attemptStart).Milliseconds(),
+			Reason:              "model_call_failed",
+			CompatibilitySignal: compatibilitySignal,
+		})
+
 		if retryable && attempt < maxRetryCount {
 			// Check if we have enough idle budget remaining for retry
 			remainingIdleBudget := sharedTracker.Remaining()
@@ -1061,8 +1214,24 @@ func (l *ChatCompletionLogic) callModelWithRetry(modelName string, params types.
 				logger.WarnC(l.ctx, "single-model retry: insufficient idle budget for retry",
 					zap.Duration("remainingIdleBudget", remainingIdleBudget),
 					zap.Duration("minRequiredBudget", minRequiredBudget))
+				l.appendDegradationEvent(model.DegradationEvent{
+					Event:      model.DegradationEventRetrySkippedInsufficientBudget,
+					Model:      modelName,
+					ModelIndex: modelIndex,
+					Attempt:    attempt + 1,
+					MaxRetries: maxRetryCount,
+					Reason:     "insufficient_idle_budget",
+				})
 				break
 			}
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventRetryScheduled,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Attempt:    attempt + 1,
+				MaxRetries: maxRetryCount,
+				Reason:     "retryable_error",
+			})
 			time.Sleep(retryInterval)
 			continue
 		}
@@ -1097,8 +1266,16 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 		return nilResp, fmt.Errorf("degradation: no valid model in order list")
 	}
 
+	l.appendDegradationEvent(model.DegradationEvent{
+		Event:         model.DegradationEventStarted,
+		Model:         ordered[0],
+		ModelIndex:    0,
+		OrderedModels: append([]string(nil), ordered...),
+		Reason:        "auto_mode",
+	})
+
 	var lastErr error
-	for _, modelName := range ordered {
+	for modelIndex, modelName := range ordered {
 		logger.InfoC(l.ctx, "degradation: attempting model",
 			zap.String("model", modelName),
 		)
@@ -1117,6 +1294,12 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 				zap.String("model", modelName),
 				zap.Error(err),
 			)
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventStopped,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Reason:     "context_canceled",
+			})
 			return nilResp, err
 		}
 		if !l.isDegradationSwitchableError(err) {
@@ -1124,6 +1307,12 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 				zap.String("model", modelName),
 				zap.Error(err),
 			)
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:      model.DegradationEventStopped,
+				Model:      modelName,
+				ModelIndex: modelIndex,
+				Reason:     "non_switchable_error",
+			})
 			return nilResp, err
 		}
 
@@ -1131,6 +1320,16 @@ func (l *ChatCompletionLogic) callWithDegradation(params types.LLMRequestParams,
 			zap.String("model", modelName),
 			zap.Error(err),
 		)
+		if modelIndex+1 < len(ordered) {
+			l.appendDegradationEvent(model.DegradationEvent{
+				Event:         model.DegradationEventModelSwitch,
+				PreviousModel: modelName,
+				Model:         ordered[modelIndex+1],
+				ModelIndex:    modelIndex + 1,
+				OrderedModels: append([]string(nil), ordered...),
+				Reason:        "previous_model_failed",
+			})
+		}
 	}
 	return nilResp, lastErr
 }
@@ -1205,7 +1404,7 @@ func (l *ChatCompletionLogic) isDegradationSwitchableError(err error) bool {
 
 		switch apiErr.StatusCode {
 		case http.StatusBadRequest:
-			return isModelCompatibilityError(apiErr)
+			return true
 		case http.StatusUnauthorized, http.StatusForbidden:
 			return false
 		case http.StatusRequestTimeout, http.StatusTooManyRequests:
@@ -1226,6 +1425,70 @@ func (l *ChatCompletionLogic) isDegradationSwitchableError(err error) bool {
 	}
 
 	return true
+}
+
+func (l *ChatCompletionLogic) appendDegradationEvent(event model.DegradationEvent) {
+	if l == nil {
+		return
+	}
+	if len(l.orderedModels) == 0 {
+		return
+	}
+	// AUTO request handling records trace events in one request goroutine.
+	if len(l.degradationTrace) >= maxDegradationTraceEvents-1 {
+		if !l.degradationTraceFull {
+			l.degradationTraceFull = true
+			l.degradationTraceSeq++
+			l.degradationTrace = append(l.degradationTrace, model.DegradationEvent{
+				Sequence:   l.degradationTraceSeq,
+				Timestamp:  time.Now(),
+				Event:      model.DegradationEventTraceTruncated,
+				ModelIndex: -1,
+				Reason:     "trace_event_limit_reached",
+			})
+		}
+		return
+	}
+	l.degradationTraceSeq++
+	event.Sequence = l.degradationTraceSeq
+	event.Timestamp = time.Now()
+	event.ErrorMessage = sanitizeDegradationErrorMessage(event.ErrorMessage)
+	l.degradationTrace = append(l.degradationTrace, event)
+}
+
+var sensitiveDegradationErrorPattern = regexp.MustCompile(`(?i)(authorization|bearer|api[-_]?key|x-api-key|secret|token)\s*[:=]\s*.{6,}`)
+
+func sanitizeDegradationErrorMessage(msg string) string {
+	msg = truncateBytes(msg, maxDegradationErrorBytes)
+	if sensitiveDegradationErrorPattern.MatchString(msg) {
+		return sensitiveDegradationErrorPattern.ReplaceAllString(msg, "$1=[redacted]")
+	}
+	return msg
+}
+
+func truncateBytes(s string, max int) string {
+	if max <= 0 || len([]byte(s)) <= max {
+		return s
+	}
+	b := []byte(s)
+	truncated := string(b[:max])
+	for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
+}
+
+func degradationErrorFields(err error) (statusCode int, errorCode string, errorType string, errorMessage string, compatibilitySignal bool) {
+	if apiErr, ok := err.(*types.APIError); ok {
+		return apiErr.StatusCode, apiErr.Code, apiErr.Type, apiErr.Message, isModelCompatibilityError(apiErr)
+	}
+	if idleErr, ok := err.(*types.IdleTimeoutError); ok {
+		return http.StatusGatewayTimeout, idleErr.Code, string(types.ErrServerModel), idleErr.Message, false
+	}
+	if err != nil {
+		return 0, "", "", err.Error(), false
+	}
+	return 0, "", "", "", false
 }
 
 func isModelCompatibilityError(err error) bool {

--- a/internal/logic/chat_auto_router_test.go
+++ b/internal/logic/chat_auto_router_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
@@ -484,4 +485,39 @@ type mockSuccessStrategy struct {
 func (m *mockSuccessStrategy) Name() string { return "mock-success" }
 func (m *mockSuccessStrategy) Run(_ context.Context, _ *bootstrap.ServiceContext, _ *http.Header, _ *types.ChatCompletionRequest) (string, string, []string, error) {
 	return m.selected, "", m.ordered, nil
+}
+
+func TestChatCompletionLogic_LogCompletionCopiesDegradationTrace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	loggerMock := mocks.NewMockLoggerInterface(ctrl)
+	var capturedLog *model.ChatLog
+	loggerMock.EXPECT().LogAsync(gomock.Any(), gomock.Any()).Do(func(log *model.ChatLog, _ *http.Header) {
+		capturedLog = log
+	})
+
+	svcCtx := &bootstrap.ServiceContext{LoggerService: loggerMock}
+	req := autoRouterRequest()
+	hdr := make(http.Header)
+	identity := autoRouterIdentityNoVip()
+	logic := NewChatCompletionLogic(context.Background(), svcCtx, req, &mockResponseWriter{}, &hdr, identity)
+	logic.orderedModels = []string{"model-a", "model-b"}
+	chatLog := logic.newChatLog(time.Now())
+
+	logic.appendDegradationEvent(model.DegradationEvent{
+		Event:      model.DegradationEventAttemptFailed,
+		Model:      "model-a",
+		ModelIndex: 0,
+		Reason:     "model_call_failed",
+	})
+
+	logic.logCompletion(chatLog)
+
+	assert.NotNil(t, capturedLog)
+	assert.Len(t, capturedLog.DegradationTrace, 1)
+	assert.Equal(t, model.DegradationEventAttemptFailed, capturedLog.DegradationTrace[0].Event)
+	assert.Equal(t, "model-a", capturedLog.DegradationTrace[0].Model)
+	assert.Equal(t, 1, capturedLog.DegradationTrace[0].Sequence)
+	assert.Empty(t, capturedLog.Error)
 }

--- a/internal/logic/chat_test.go
+++ b/internal/logic/chat_test.go
@@ -3,7 +3,9 @@ package logic
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
@@ -285,4 +287,134 @@ func TestChatCompletionLogic_ChatCompletion_StreamingRequest(t *testing.T) {
 	// Verify response write attempt
 	assert.Greater(t, len(testWriter.data), 0, "Expected response attempt data")
 	assert.True(t, testWriter.flushed, "Expected response flush attempt")
+}
+
+func TestChatCompletionLogic_ErrorClassification_BadRequestDoesNotRetryButCanDegrade(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := &types.APIError{
+		Code:       types.ErrCodeModelServiceUnavailable,
+		Message:    "downstream bad request: missing prompt",
+		Success:    false,
+		StatusCode: http.StatusBadRequest,
+		Type:       string(types.ErrServerModel),
+	}
+
+	assert.False(t, logic.isSameModelRetryableError(err))
+	assert.True(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestChatCompletionLogic_ErrorClassification_EmptyMessageBadRequestDoesNotDegrade(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := types.NewEmptyMessageContentError()
+
+	assert.False(t, logic.isSameModelRetryableError(err))
+	assert.False(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestChatCompletionLogic_ErrorClassification_UnauthorizedDoesNotDegrade(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := &types.APIError{
+		Code:       types.ErrCodeUnauthorized,
+		Message:    types.ErrMsgUnauthorized,
+		Success:    false,
+		StatusCode: http.StatusUnauthorized,
+		Type:       string(types.ErrServerModel),
+	}
+
+	assert.False(t, logic.isSameModelRetryableError(err))
+	assert.False(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestChatCompletionLogic_ErrorClassification_TooManyRequestsDoesNotRetryButCanDegrade(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := &types.APIError{
+		Code:       types.ErrCodeTooManyRequests,
+		Message:    types.ErrMsgTooManyRequests,
+		Success:    false,
+		StatusCode: http.StatusTooManyRequests,
+		Type:       string(types.ErrServerModel),
+	}
+
+	assert.False(t, logic.isSameModelRetryableError(err))
+	assert.True(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestChatCompletionLogic_ErrorClassification_ServerErrorRetriesAndDegrades(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := &types.APIError{
+		Code:       types.ErrCodeModelServiceUnavailable,
+		Message:    types.ErrMsgModelServiceUnavailable,
+		Success:    false,
+		StatusCode: http.StatusInternalServerError,
+		Type:       string(types.ErrServerModel),
+	}
+
+	assert.True(t, logic.isSameModelRetryableError(err))
+	assert.True(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestChatCompletionLogic_ErrorClassification_IdleTimeoutRetriesAndDegrades(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
+	err := types.NewStreamIdleTimeoutError()
+
+	assert.True(t, logic.isSameModelRetryableError(err))
+	assert.True(t, logic.isDegradationSwitchableError(err))
+}
+
+func TestTruncateBytes_UTF8Safe(t *testing.T) {
+	assert.Equal(t, "hello", truncateBytes("hello", 100))
+	assert.Equal(t, "", truncateBytes("", 10))
+
+	s := strings.Repeat("é", 300)
+	r := truncateBytes(s, 7)
+	assert.LessOrEqual(t, len([]byte(r)), 7)
+	assert.True(t, utf8.ValidString(r), "truncated string must be valid UTF-8")
+
+	assert.Equal(t, "abc", truncateBytes("abc", 0), "max<=0 means no truncation")
+}
+
+func TestSanitizeDegradationErrorMessage_Redaction(t *testing.T) {
+	result := sanitizeDegradationErrorMessage("authorization: Bearer abcdef123456")
+	assert.NotContains(t, result, "abcdef123456")
+	assert.Contains(t, result, "[redacted]")
+
+	result = sanitizeDegradationErrorMessage("token=supersecretvalue")
+	assert.NotContains(t, result, "supersecretvalue")
+	assert.Contains(t, result, "[redacted]")
+
+	result = sanitizeDegradationErrorMessage("invalid token count: 5")
+	assert.Equal(t, "invalid token count: 5", result)
+}
+
+func TestAppendDegradationEvent_CapAndTruncation(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hi"}}, &mockResponseWriter{})
+	logic.orderedModels = []string{"m1", "m2"}
+
+	for i := 0; i < 100; i++ {
+		logic.appendDegradationEvent(model.DegradationEvent{Event: model.DegradationEventAttemptStarted, Model: "m1", ModelIndex: 0})
+	}
+
+	assert.Equal(t, maxDegradationTraceEvents, len(logic.degradationTrace))
+	assert.Equal(t, model.DegradationEventTraceTruncated, logic.degradationTrace[len(logic.degradationTrace)-1].Event)
+	assert.True(t, logic.degradationTraceFull)
+	assert.Equal(t, maxDegradationTraceEvents, logic.degradationTraceSeq)
+	for i, ev := range logic.degradationTrace {
+		assert.Equal(t, i+1, ev.Sequence, "sequences should be monotonically increasing")
+	}
+}
+
+func TestDegradationModelIndex(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hi"}}, &mockResponseWriter{})
+	logic.orderedModels = []string{"m1", "m2", "m3"}
+	assert.Equal(t, 0, logic.degradationModelIndex("m1"))
+	assert.Equal(t, 2, logic.degradationModelIndex("m3"))
+	assert.Equal(t, -1, logic.degradationModelIndex("missing"))
+}
+
+func TestAppendDegradationEvent_NoopWithoutOrderedModels(t *testing.T) {
+	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hi"}}, &mockResponseWriter{})
+	// DO NOT set orderedModels — leave it empty/nil
+
+	logic.appendDegradationEvent(model.DegradationEvent{Event: model.DegradationEventAttemptStarted, Model: "m1", ModelIndex: 0})
+	assert.Equal(t, 0, len(logic.degradationTrace))
 }

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -71,15 +71,53 @@ type ChatLog struct {
 	ProcessedPrompt []types.Message `json:"processed_prompt"`
 
 	// Response information
-	ResponseHeaders []map[string]string  `json:"response_headers,omitempty"`
+	ResponseHeaders []map[string]string    `json:"response_headers,omitempty"`
 	ResponseContent *types.ResponseContent `json:"response_content,omitempty"`
-	Usage           types.Usage          `json:"usage,omitempty"`
+	Usage           types.Usage            `json:"usage,omitempty"`
 
 	// Classification (will be filled by async processor)
 	Category string `json:"category,omitempty"`
 
 	// Error information
 	Error []map[types.ErrorType]string `json:"error,omitempty"`
+
+	// Degradation trace
+	DegradationTrace []DegradationEvent `json:"degradation_trace,omitempty"`
+}
+
+type DegradationEventType string
+
+const (
+	DegradationEventStarted                        DegradationEventType = "degradation_started"
+	DegradationEventAttemptStarted                 DegradationEventType = "attempt_started"
+	DegradationEventAttemptFailed                  DegradationEventType = "attempt_failed"
+	DegradationEventRetryScheduled                 DegradationEventType = "retry_scheduled"
+	DegradationEventRetrySkippedInsufficientBudget DegradationEventType = "retry_skipped_insufficient_budget"
+	DegradationEventModelSwitch                    DegradationEventType = "model_switch"
+	DegradationEventStopped                        DegradationEventType = "degradation_stopped"
+	DegradationEventModelSucceeded                 DegradationEventType = "model_succeeded"
+	DegradationEventTraceTruncated                 DegradationEventType = "trace_truncated"
+)
+
+type DegradationEvent struct {
+	Sequence            int                  `json:"sequence"`
+	Timestamp           time.Time            `json:"timestamp"`
+	Event               DegradationEventType `json:"event"`
+	Model               string               `json:"model,omitempty"`
+	PreviousModel       string               `json:"previous_model,omitempty"`
+	OrderedModels       []string             `json:"ordered_models,omitempty"`
+	ModelIndex          int                  `json:"model_index"`
+	Attempt             int                  `json:"attempt,omitempty"`
+	MaxRetries          int                  `json:"max_retries,omitempty"`
+	Retryable           *bool                `json:"retryable,omitempty"`
+	Switchable          *bool                `json:"switchable,omitempty"`
+	StatusCode          int                  `json:"status_code,omitempty"`
+	ErrorCode           string               `json:"error_code,omitempty"`
+	ErrorType           string               `json:"error_type,omitempty"`
+	ErrorMessage        string               `json:"error_message,omitempty"`
+	ElapsedMs           int64                `json:"elapsed_ms,omitempty"`
+	Reason              string               `json:"reason,omitempty"`
+	CompatibilitySignal bool                 `json:"compatibility_signal,omitempty"`
 }
 
 // toStringJSON converts the log entry to indented JSON string


### PR DESCRIPTION
# AUTO 降级追踪实现计划

**目标：** 让 AUTO 模式将下游模型返回的 `400 BadRequest` 视为可跨模型切换，但不可在同一模型上重试，并在最终的 `ChatLog` 中一次性持久化完整的 AUTO 重试/降级追踪。

**架构：** 重试/降级决策仍保留在 `internal/logic/chat.go` 中。AUTO 模式将结构化事件追加到 `ChatCompletionLogic` 的请求本地运行时状态中，然后在最终 `logCompletion` 时将该状态复制到 `model.ChatLog`；现有的 `LogAsync -> logDirectToStorage` 路径会持久化一个最终 ChatLog。中间尝试失败不会写入 `ChatLog.Error`，因此带有 fallback 的成功请求不会被计为失败请求。

**技术栈：** Go、现有 `model.ChatLog` JSON 持久化、现有 `LoggerRecordService.logDirectToStorage`、Go 单元测试。

---

## 已达成的决策

- 下游模型的 `400 BadRequest` 不可在同一模型上重试，但可触发 AUTO 降级切换。
- 同一模型重试策略保持不变。
- AUTO 追踪仅记录使用 `orderedModels` 的 AUTO 模式路径。
- 追踪在请求处理期间以内存形式累积，并在最终 ChatLog 中一次性持久化。
- 不要针对每个重试/降级事件调用 `logDirectToStorage`。
- 不要将中间尝试失败写入 `ChatLog.Error`。
- 暂时保持 `401/403` 不可切换，因为当前凭证和 header 是全局的，而不是按模型区分的。
- 暂时保持上下文长度错误不可切换；后续工作可以区分下游模型上下文限制与本地预检查上下文限制。
- 本次变更后，`isModelCompatibilityError` 不再作为降级门控；如有用，可仅保留为追踪标签辅助函数。

## 文件结构

- 修改 `internal/model/log.go`
  - 向 `ChatLog` 添加 `DegradationTrace []DegradationEvent`。
  - 添加 `DegradationEvent` 和类型化事件常量。
- 修改 `internal/logic/chat.go`
  - 向 `ChatCompletionLogic` 添加请求本地追踪状态。
  - 添加用于追加有上限且已清洗事件的辅助函数。
  - 在 `logCompletion` 中将追踪复制到 `ChatLog`。
  - 修改下游 `400` 的可切换性。
  - 在真正执行同一模型重试的 `callModelWithRetry` 中记录 AUTO 非流式重试尝试。
  - 在 `callWithDegradation` 中记录 AUTO 跨模型切换。
  - 在流式降级循环中记录 AUTO 流式重试和降级。
- 修改 `internal/logic/chat_test.go`
  - 添加重试/可切换分类的决策测试。
- 修改 `internal/logic/chat_auto_router_test.go`
  - 添加 AUTO 追踪测试，检查传给 `LoggerService.LogAsync` 的最终 ChatLog。
- 仅在刷新 mock 生成结果时修改 `internal/service/mocks/mock_logger.go`；默认计划不需要接口变更。

## 事件 Schema

在 `internal/model/log.go` 中添加以下结构：

```go
type DegradationEventType string

const (
	DegradationEventStarted                         DegradationEventType = "degradation_started"
	DegradationEventAttemptStarted                  DegradationEventType = "attempt_started"
	DegradationEventAttemptFailed                   DegradationEventType = "attempt_failed"
	DegradationEventRetryScheduled                  DegradationEventType = "retry_scheduled"
	DegradationEventRetrySkippedInsufficientBudget  DegradationEventType = "retry_skipped_insufficient_budget"
	DegradationEventModelSwitch                     DegradationEventType = "model_switch"
	DegradationEventStopped                         DegradationEventType = "degradation_stopped"
	DegradationEventModelSucceeded                  DegradationEventType = "model_succeeded"
	DegradationEventTraceTruncated                  DegradationEventType = "trace_truncated"
)

type DegradationEvent struct {
	Sequence            int                  `json:"sequence"`
	Timestamp           time.Time            `json:"timestamp"`
	Event               DegradationEventType `json:"event"`
	Model               string               `json:"model,omitempty"`
	PreviousModel       string               `json:"previous_model,omitempty"`
	OrderedModels       []string             `json:"ordered_models,omitempty"`
	ModelIndex          int                  `json:"model_index"`
	Attempt             int                  `json:"attempt,omitempty"`
	MaxRetries          int                  `json:"max_retries,omitempty"`
	Retryable           *bool                `json:"retryable,omitempty"`
	Switchable          *bool                `json:"switchable,omitempty"`
	StatusCode          int                  `json:"status_code,omitempty"`
	ErrorCode           string               `json:"error_code,omitempty"`
	ErrorType           string               `json:"error_type,omitempty"`
	ErrorMessage        string               `json:"error_message,omitempty"`
	ElapsedMs           int64                `json:"elapsed_ms,omitempty"`
	Reason              string               `json:"reason,omitempty"`
	CompatibilitySignal bool                 `json:"compatibility_signal,omitempty"`
}
```

向 `ChatLog` 添加此字段：

```go
DegradationTrace []DegradationEvent `json:"degradation_trace,omitempty"`
```

对 `Retryable` 和 `Switchable` 使用 `*bool`，这样在 JSON 中可以区分“省略”和 `false`。

## 追踪规则

- 追踪上限：总共 64 个事件。
- 为最终的 `trace_truncated` 保留最后一个追踪槽位：最多 63 个普通事件加 1 个截断事件。
- 一旦追加了 `trace_truncated`，后续事件将被丢弃，不替换之前的真实事件。
- `error_message` 最多截断到 512 字节，并且截断后必须保持有效 UTF-8。
- 仅在看起来像 key/value 形式的密钥时才脱敏敏感数据，使用不区分大小写的模式，例如 `(authorization|bearer|api[-_]?key|x-api-key|secret|token)\s*[:=]\s*\S{6,}`。这样可以避免删除有用的调试文本，例如 `invalid token count`。
- `elapsed_ms` 表示从当前尝试开始到该事件发生的持续时间。

---

### 任务 1：添加失败的分类测试

**文件：**
- 修改：`internal/logic/chat_test.go`
- 测试：`internal/logic/chat_test.go`

- [ ] **步骤 1：编写预期失败的测试**

追加直接调用 `isSameModelRetryableError` 和 `isDegradationSwitchableError` 的测试：

```go
func TestChatCompletionLogic_ErrorClassification_BadRequestDoesNotRetryButCanDegrade(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := &types.APIError{
		Code:       types.ErrCodeModelServiceUnavailable,
		Message:    "downstream bad request: missing prompt",
		Success:    false,
		StatusCode: http.StatusBadRequest,
		Type:       string(types.ErrServerModel),
	}

	assert.False(t, logic.isSameModelRetryableError(err))
	assert.True(t, logic.isDegradationSwitchableError(err))
}

func TestChatCompletionLogic_ErrorClassification_EmptyMessageBadRequestDoesNotDegrade(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := types.NewEmptyMessageContentError()

	assert.False(t, logic.isSameModelRetryableError(err))
	assert.False(t, logic.isDegradationSwitchableError(err))
}

func TestChatCompletionLogic_ErrorClassification_UnauthorizedDoesNotDegrade(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := &types.APIError{
		Code:       types.ErrCodeUnauthorized,
		Message:    types.ErrMsgUnauthorized,
		Success:    false,
		StatusCode: http.StatusUnauthorized,
		Type:       string(types.ErrServerModel),
	}

	assert.False(t, logic.isSameModelRetryableError(err))
	assert.False(t, logic.isDegradationSwitchableError(err))
}

func TestChatCompletionLogic_ErrorClassification_TooManyRequestsDoesNotRetryButCanDegrade(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := &types.APIError{
		Code:       types.ErrCodeTooManyRequests,
		Message:    types.ErrMsgTooManyRequests,
		Success:    false,
		StatusCode: http.StatusTooManyRequests,
		Type:       string(types.ErrServerModel),
	}

	assert.False(t, logic.isSameModelRetryableError(err))
	assert.True(t, logic.isDegradationSwitchableError(err))
}

func TestChatCompletionLogic_ErrorClassification_ServerErrorRetriesAndDegrades(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := &types.APIError{
		Code:       types.ErrCodeModelServiceUnavailable,
		Message:    types.ErrMsgModelServiceUnavailable,
		Success:    false,
		StatusCode: http.StatusInternalServerError,
		Type:       string(types.ErrServerModel),
	}

	assert.True(t, logic.isSameModelRetryableError(err))
	assert.True(t, logic.isDegradationSwitchableError(err))
}

func TestChatCompletionLogic_ErrorClassification_IdleTimeoutRetriesAndDegrades(t *testing.T) {
	logic, _ := setupTestLogic(t, &config.Config{}, nil, "auto", []types.Message{{Role: types.RoleUser, Content: "hello"}}, &mockResponseWriter{})
	err := types.NewStreamIdleTimeoutError()

	assert.True(t, logic.isSameModelRetryableError(err))
	assert.True(t, logic.isDegradationSwitchableError(err))
}
```

- [ ] **步骤 2：运行测试以确认新的 bad-request 测试失败**

运行：

```powershell
go test ./internal/logic -run "TestChatCompletionLogic_ErrorClassification" -count=1
```

预期结果：`TestChatCompletionLogic_ErrorClassification_BadRequestDoesNotRetryButCanDegrade` 失败，因为当前的 `400` 可切换性取决于 `isModelCompatibilityError`。

### 任务 2：添加追踪模型类型

**文件：**
- 修改：`internal/model/log.go`
- 测试：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：添加追踪类型和 ChatLog 字段**

修改 `internal/model/log.go`：

```go
type DegradationEventType string

const (
	DegradationEventStarted                        DegradationEventType = "degradation_started"
	DegradationEventAttemptStarted                 DegradationEventType = "attempt_started"
	DegradationEventAttemptFailed                  DegradationEventType = "attempt_failed"
	DegradationEventRetryScheduled                 DegradationEventType = "retry_scheduled"
	DegradationEventRetrySkippedInsufficientBudget DegradationEventType = "retry_skipped_insufficient_budget"
	DegradationEventModelSwitch                    DegradationEventType = "model_switch"
	DegradationEventStopped                        DegradationEventType = "degradation_stopped"
	DegradationEventModelSucceeded                 DegradationEventType = "model_succeeded"
	DegradationEventTraceTruncated                 DegradationEventType = "trace_truncated"
)

type DegradationEvent struct {
	Sequence            int                  `json:"sequence"`
	Timestamp           time.Time            `json:"timestamp"`
	Event               DegradationEventType `json:"event"`
	Model               string               `json:"model,omitempty"`
	PreviousModel       string               `json:"previous_model,omitempty"`
	OrderedModels       []string             `json:"ordered_models,omitempty"`
	ModelIndex          int                  `json:"model_index"`
	Attempt             int                  `json:"attempt,omitempty"`
	MaxRetries          int                  `json:"max_retries,omitempty"`
	Retryable           *bool                `json:"retryable,omitempty"`
	Switchable          *bool                `json:"switchable,omitempty"`
	StatusCode          int                  `json:"status_code,omitempty"`
	ErrorCode           string               `json:"error_code,omitempty"`
	ErrorType           string               `json:"error_type,omitempty"`
	ErrorMessage        string               `json:"error_message,omitempty"`
	ElapsedMs           int64                `json:"elapsed_ms,omitempty"`
	Reason              string               `json:"reason,omitempty"`
	CompatibilitySignal bool                 `json:"compatibility_signal,omitempty"`
}
```

向 `ChatLog` 添加：

```go
DegradationTrace []DegradationEvent `json:"degradation_trace,omitempty"`
```

- [ ] **步骤 2：运行模型序列化冒烟测试**

运行：

```powershell
go test ./internal/model -count=1
```

预期结果：包可以编译，现有测试通过。

### 任务 3：修改 400 可切换性

**文件：**
- 修改：`internal/logic/chat.go`
- 测试：`internal/logic/chat_test.go`

- [ ] **步骤 1：修改 `isDegradationSwitchableError`**

修改 `StatusBadRequest` 分支：

```go
case http.StatusBadRequest:
	return true
```

保留位于状态码 switch 之前的这段代码：

```go
switch apiErr.Code {
case types.ErrCodeContextExceeded,
	types.ErrCodeUnauthorized,
	types.ErrCodeEmptyMessageContent:
	return false
}
```

保持以下状态码分支不变：

```go
case http.StatusUnauthorized, http.StatusForbidden:
	return false
```

- [ ] **步骤 2：运行分类测试**

运行：

```powershell
go test ./internal/logic -run "TestChatCompletionLogic_ErrorClassification" -count=1
```

预期结果：所有分类测试通过。

### 任务 4：添加运行时追踪辅助函数

**文件：**
- 修改：`internal/logic/chat.go`
- 测试：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：向 `ChatCompletionLogic` 添加字段**

添加字段：

```go
degradationTrace      []model.DegradationEvent
degradationTraceSeq   int
degradationTraceFull  bool
```

添加常量：

```go
const (
	maxDegradationTraceEvents = 64
	maxDegradationErrorBytes  = 512
)
```

- [ ] **步骤 2：添加 append 辅助函数**

在 `internal/logic/chat.go` 中添加辅助方法：

```go
func (l *ChatCompletionLogic) appendDegradationEvent(event model.DegradationEvent) {
	if l == nil {
		return
	}
	if len(l.orderedModels) == 0 {
		return
	}
	// AUTO request handling records trace events in one request goroutine.
	if len(l.degradationTrace) >= maxDegradationTraceEvents-1 {
		if !l.degradationTraceFull {
			l.degradationTraceFull = true
			l.degradationTraceSeq++
			l.degradationTrace = append(l.degradationTrace, model.DegradationEvent{
				Sequence:  l.degradationTraceSeq,
				Timestamp: time.Now(),
				Event:     model.DegradationEventTraceTruncated,
				ModelIndex: -1,
				Reason:    "trace_event_limit_reached",
			})
		}
		return
	}
	l.degradationTraceSeq++
	event.Sequence = l.degradationTraceSeq
	event.Timestamp = time.Now()
	event.ErrorMessage = sanitizeDegradationErrorMessage(event.ErrorMessage)
	l.degradationTrace = append(l.degradationTrace, event)
}
```

添加清洗辅助函数：

```go
func sanitizeDegradationErrorMessage(msg string) string {
	msg = truncateBytes(msg, maxDegradationErrorBytes)
	if sensitiveDegradationErrorPattern.MatchString(msg) {
		return sensitiveDegradationErrorPattern.ReplaceAllString(msg, "$1=[redacted]")
	}
	return msg
}

func truncateBytes(s string, max int) string {
	if max <= 0 || len([]byte(s)) <= max {
		return s
	}
	b := []byte(s)
	truncated := string(b[:max])
	for !utf8.ValidString(truncated) && len(truncated) > 0 {
		truncated = truncated[:len(truncated)-1]
	}
	return truncated
}
```

在该辅助函数附近定义一次正则：

```go
var sensitiveDegradationErrorPattern = regexp.MustCompile(`(?i)(authorization|bearer|api[-_]?key|x-api-key|secret|token)\s*[:=]\s*\S{6,}`)
```

此辅助函数需要在 `internal/logic/chat.go` 中导入 `regexp` 和 `unicode/utf8`。

- [ ] **步骤 3：添加 API 错误提取辅助函数**

添加：

```go
func degradationErrorFields(err error) (statusCode int, errorCode string, errorType string, errorMessage string, compatibilitySignal bool) {
	if apiErr, ok := err.(*types.APIError); ok {
		return apiErr.StatusCode, apiErr.Code, apiErr.Type, apiErr.Message, isModelCompatibilityError(apiErr)
	}
	if idleErr, ok := err.(*types.IdleTimeoutError); ok {
		return http.StatusGatewayTimeout, idleErr.Code, string(types.ErrServerModel), idleErr.Message, false
	}
	if err != nil {
		return 0, "", "", err.Error(), false
	}
	return 0, "", "", "", false
}
```

- [ ] **步骤 4：将追踪复制到最终 ChatLog**

在 `logCompletion` 中、`LogAsync` 之前添加：

```go
if len(l.degradationTrace) > 0 {
	chatLog.DegradationTrace = append([]model.DegradationEvent(nil), l.degradationTrace...)
}
```

### 任务 5：记录 AUTO 非流式追踪

**文件：**
- 修改：`internal/logic/chat.go`
- 测试：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：添加追踪模型索引辅助函数**

添加：

```go
func (l *ChatCompletionLogic) degradationModelIndex(modelName string) int {
	for i, ordered := range l.orderedModels {
		if ordered == modelName {
			return i
		}
	}
	return -1
}
```

- [ ] **步骤 2：在 `callModelWithRetry` 中记录重试尝试**

`callWithDegradation` 看不到同一模型重试尝试，因为重试发生在 `callModelWithRetry` 内部。请在 `callModelWithRetry` 中使用实际的 `attempt` 循环值记录 `attempt_started`、`attempt_failed`、`retry_scheduled`、`retry_skipped_insufficient_budget` 和 `model_succeeded`。

在每次尝试开始时：

```go
modelIndex := l.degradationModelIndex(modelName)
attemptStart := time.Now()
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventAttemptStarted,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
})
```

成功时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventModelSucceeded,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	ElapsedMs:  time.Since(attemptStart).Milliseconds(),
	Reason:     "model_call_succeeded",
})
```

失败后，在计算出 `retryable` 之后：

```go
switchable := l.isDegradationSwitchableError(err)
statusCode, errorCode, errorType, errorMessage, compatibilitySignal := degradationErrorFields(err)
l.appendDegradationEvent(model.DegradationEvent{
	Event:               model.DegradationEventAttemptFailed,
	Model:               modelName,
	ModelIndex:          modelIndex,
	Attempt:             attempt + 1,
	MaxRetries:          maxRetryCount,
	Retryable:           &retryable,
	Switchable:          &switchable,
	StatusCode:          statusCode,
	ErrorCode:           errorCode,
	ErrorType:           errorType,
	ErrorMessage:        errorMessage,
	ElapsedMs:           time.Since(attemptStart).Milliseconds(),
	Reason:              "model_call_failed",
	CompatibilitySignal: compatibilitySignal,
})
```

计划重试时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventRetryScheduled,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	Reason:     "retryable_error",
})
```

因 idle budget 不足而跳过重试时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventRetrySkippedInsufficientBudget,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	Reason:     "insufficient_idle_budget",
})
```

由于 `appendDegradationEvent` 会在 `orderedModels` 为空时 no-op，因此这不会记录非 AUTO 单模型重试。

- [ ] **步骤 3：在 `callWithDegradation` 中记录降级生命周期**

在 `callWithDegradation` 中，构建 `ordered` 后追加：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:         model.DegradationEventStarted,
	Model:         ordered[0],
	ModelIndex:    0,
	OrderedModels: append([]string(nil), ordered...),
	Reason:        "auto_mode",
})
```

在模型循环中使用索引：

```go
for modelIndex, modelName := range ordered {
```

不要在 `callWithDegradation` 中记录 `attempt_started`、`attempt_failed`、`retry_scheduled`、`retry_skipped_insufficient_budget` 或 `model_succeeded`；这些事件应在 `callModelWithRetry` 内记录，因为那里可以获得真实的重试尝试次数和耗时。

如果 context 已取消：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventStopped,
	Model:      modelName,
	ModelIndex: modelIndex,
	Reason:     "context_canceled",
})
```

如果不可切换：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventStopped,
	Model:      modelName,
	ModelIndex: modelIndex,
	Reason:     "non_switchable_error",
})
```

切换到下一个模型之前：

```go
if modelIndex+1 < len(ordered) {
	l.appendDegradationEvent(model.DegradationEvent{
		Event:         model.DegradationEventModelSwitch,
		PreviousModel: modelName,
		Model:         ordered[modelIndex+1],
		ModelIndex:    modelIndex + 1,
		OrderedModels: append([]string(nil), ordered...),
		Reason:        "previous_model_failed",
	})
}
```

### 任务 6：记录 AUTO 流式追踪

**文件：**
- 修改：`internal/logic/chat.go`
- 测试：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：记录流式降级生命周期**

在流式 AUTO 路径中，在 `models := l.orderedModels` 之后添加：

```go
if len(models) > 0 {
	l.appendDegradationEvent(model.DegradationEvent{
		Event:         model.DegradationEventStarted,
		Model:         models[0],
		ModelIndex:    0,
		OrderedModels: append([]string(nil), models...),
		MaxRetries:    maxRetryCount,
		Reason:        "auto_mode_stream",
	})
}
```

将循环改为：

```go
for modelIndex, modelName := range models {
```

每次尝试之前：

```go
attemptStart := time.Now()
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventAttemptStarted,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
})
```

在首个 token 之前失败时：

```go
retryable := l.isSameModelRetryableError(err)
switchable := l.isDegradationSwitchableError(err)
statusCode, errorCode, errorType, errorMessage, compatibilitySignal := degradationErrorFields(err)
l.appendDegradationEvent(model.DegradationEvent{
	Event:               model.DegradationEventAttemptFailed,
	Model:               modelName,
	ModelIndex:          modelIndex,
	Attempt:             attempt + 1,
	MaxRetries:          maxRetryCount,
	Retryable:           &retryable,
	Switchable:          &switchable,
	StatusCode:          statusCode,
	ErrorCode:           errorCode,
	ErrorType:           errorType,
	ErrorMessage:        errorMessage,
	ElapsedMs:           time.Since(attemptStart).Milliseconds(),
	Reason:              "stream_failed_before_first_token",
	CompatibilitySignal: compatibilitySignal,
})
```

在 stream 已提交时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventStopped,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	Reason:     "stream_committed",
})
```

计划重试时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventRetryScheduled,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	Reason:     "retryable_error",
})
```

idle budget 不足时：

```go
l.appendDegradationEvent(model.DegradationEvent{
	Event:      model.DegradationEventRetrySkippedInsufficientBudget,
	Model:      modelName,
	ModelIndex: modelIndex,
	Attempt:    attempt + 1,
	MaxRetries: maxRetryCount,
	Reason:     "insufficient_idle_budget",
})
```

对于模型切换、停止和成功，使用与非流式路径相同的事件形状。

### 任务 7：添加 AUTO 追踪测试

**文件：**
- 修改：`internal/logic/chat_auto_router_test.go`
- 测试：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：添加最终 ChatLog 捕获辅助代码**

使用 GoMock 的 `Do` 捕获最终日志：

```go
var capturedLog *model.ChatLog
loggerMock.EXPECT().
	LogAsync(gomock.Any(), gomock.Any()).
	Do(func(log *model.ChatLog, _ *http.Header) {
		capturedLog = log
	}).
	AnyTimes()
```

- [ ] **步骤 2：如果难以伪造直接模型调用，则添加单元级追踪辅助测试**

如果在不重构 `client.NewLLMClient` 的情况下很难完成完整的模型客户端伪造，请添加针对追踪追加和最终复制的直接测试：

```go
func TestChatCompletionLogic_LogCompletionCopiesDegradationTrace(t *testing.T) {
	ctrl := gomock.NewController(t)
	defer ctrl.Finish()

	loggerMock := mocks.NewMockLoggerInterface(ctrl)
	var capturedLog *model.ChatLog
	loggerMock.EXPECT().LogAsync(gomock.Any(), gomock.Any()).Do(func(log *model.ChatLog, _ *http.Header) {
		capturedLog = log
	})

	svcCtx := &bootstrap.ServiceContext{LoggerService: loggerMock}
	req := autoRouterRequest()
	hdr := make(http.Header)
	identity := autoRouterIdentityNoVip()
	logic := NewChatCompletionLogic(context.Background(), svcCtx, req, &mockResponseWriter{}, &hdr, identity)
	chatLog := logic.newChatLog(time.Now())

	logic.appendDegradationEvent(model.DegradationEvent{
		Event:      model.DegradationEventAttemptFailed,
		Model:      "model-a",
		ModelIndex: 0,
		Reason:     "model_call_failed",
	})

	logic.logCompletion(chatLog)

	assert.NotNil(t, capturedLog)
	assert.Len(t, capturedLog.DegradationTrace, 1)
	assert.Equal(t, model.DegradationEventAttemptFailed, capturedLog.DegradationTrace[0].Event)
	assert.Empty(t, capturedLog.Error)
}
```

- [ ] **步骤 3：运行 AUTO 追踪测试**

运行：

```powershell
go test ./internal/logic -run "TestChatCompletionLogic_LogCompletionCopiesDegradationTrace|TestAutoRouter" -count=1
```

预期结果：追踪复制测试通过；现有 AUTO router 测试继续通过。

### 任务 8：验证

**文件：**
- 验证：`internal/logic/chat.go`
- 验证：`internal/model/log.go`
- 验证：`internal/logic/chat_test.go`
- 验证：`internal/logic/chat_auto_router_test.go`

- [ ] **步骤 1：运行定向测试**

运行：

```powershell
go test ./internal/model ./internal/logic -count=1
```

预期结果：所有测试通过。

- [ ] **步骤 2：运行更广泛的测试**

运行：

```powershell
go test ./internal/... -count=1
```

预期结果：所有测试通过，但需要不可用服务的已记录外部集成测试除外。

- [ ] **步骤 3：检查 git diff**

运行：

```powershell
git diff -- internal/model/log.go internal/logic/chat.go internal/logic/chat_test.go internal/logic/chat_auto_router_test.go
```

预期结果：diff 仅包含追踪 schema、400 可切换性变更、AUTO 追踪记录和测试。

## 预期最终 JSON 形状

一次成功的 AUTO fallback 请求应持久化一个形如下方的 ChatLog：

```json
{
  "params": {
    "model": "auto",
    "routed_model": "DeepSeek-V3"
  },
  "degradation_trace": [
    {
      "sequence": 1,
      "event": "degradation_started",
      "model": "GLM-5.1-Zhipu",
      "model_index": 0,
      "ordered_models": ["GLM-5.1-Zhipu", "DeepSeek-V3"],
      "reason": "auto_mode"
    },
    {
      "sequence": 2,
      "event": "attempt_started",
      "model": "GLM-5.1-Zhipu",
      "model_index": 0,
      "attempt": 1,
      "max_retries": 1
    },
    {
      "sequence": 3,
      "event": "attempt_failed",
      "model": "GLM-5.1-Zhipu",
      "model_index": 0,
      "attempt": 1,
      "max_retries": 1,
      "retryable": false,
      "switchable": true,
      "status_code": 400,
      "error_code": "chat-rag.model_services_unavailable",
      "error_type": "ai_model_error",
      "error_message": "Unable to access the AI model services. [Error Detail]: Code: 400 Message: {\"error\":{\"code\":\"1213\",\"message\":\"未正常接收到prompt参数。\"}}",
      "reason": "model_call_failed",
      "compatibility_signal": false
    },
    {
      "sequence": 4,
      "event": "model_switch",
      "previous_model": "GLM-5.1-Zhipu",
      "model": "DeepSeek-V3",
      "model_index": 1,
      "reason": "previous_model_failed"
    },
    {
      "sequence": 5,
      "event": "model_succeeded",
      "model": "DeepSeek-V3",
      "model_index": 1,
      "attempt": 1,
      "reason": "model_call_succeeded"
    }
  ]
}
```

## 本计划未包含的后续开放事项

- 后续可以通过支持按模型配置凭证来允许 `401/403` 降级。
- 在 router 知道候选模型上下文窗口之后，可以重新评估上下文长度降级。
- 如果运维需要在请求完成前持久化进行中的事件，可以后续添加单独的实时 `LogEvent` JSONL 管道。
