### PR TITLE
Feat/error log sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Log:
   LogScanIntervalSec: 60
   ClassifyModel: "deepseek-v3"
   EnableClassification: true
+  # Error log persistence: all | sampled | none.
+  # sampled keeps errorLogSampleN error logs per user per error type per window.
+  errorLogMode: sampled
+  errorLogSampleN: 1
+  errorLogSampleWindowSec: 60
 
 # Redis (optional)
 Redis:
@@ -252,6 +257,8 @@ router:
   - `LokiEndpoint`: Loki push endpoint.
   - `LogScanIntervalSec`: Scan/upload interval in seconds.
   - `ClassifyModel` / `EnableClassification`: Optional LLM-based log categorization.
+  - `errorLogMode`: Error log persistence policy: `all`, `sampled`, or `none`. Defaults to the deprecated `saveErrorLog` fallback when empty.
+  - `errorLogSampleN` / `errorLogSampleWindowSec`: Sampling parameters for `sampled` mode (default N=1, window=60s).
 - **Redis**: Optional; used by tools, router dynamic metrics, and transient statuses.
 - **router** (Model Selection Router)
   - `enabled` / `strategy`: Enable router; available strategies: `semantic` (semantic-based), `priority` (priority-based round-robin).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,11 @@ Log:
   LogScanIntervalSec: 60
   ClassifyModel: "deepseek-v3"
   EnableClassification: true
+  # 错误日志持久化策略：all | sampled | none。
+  # sampled 模式在每个时间窗内，每用户每错误类型最多保留 errorLogSampleN 条。
+  errorLogMode: sampled
+  errorLogSampleN: 1
+  errorLogSampleWindowSec: 60
 
 # Redis（可选）
 Redis:
@@ -252,6 +257,8 @@ router:
   - `LokiEndpoint`：Loki Push 端点
   - `LogScanIntervalSec`：日志扫描与上传周期
   - `ClassifyModel` / `EnableClassification`：是否使用 LLM 对日志分类
+  - `errorLogMode`：错误日志持久化策略：`all`、`sampled` 或 `none`。为空时回落至已弃用的 `saveErrorLog`
+  - `errorLogSampleN` / `errorLogSampleWindowSec`：`sampled` 模式的采样参数（默认 N=1，窗口=60s）
 - **Redis**：可选；用于工具状态、路由动态指标等
 - **router**（模型选择路由）
   - `enabled` / `strategy`：启用路由；可选策略：`semantic`（语义路由）、`priority`（优先级轮询）

--- a/etc/chat-api.yaml
+++ b/etc/chat-api.yaml
@@ -7,9 +7,18 @@ Log:
   LogFilePath: "logs/"
   # Storage type: "disk" (default) or "s3"
   storageType: "disk"
-  # Whether to save logs that contain errors to permanent storage.
-  # false: skip saving logs with errors (metrics are still reported).
-  # true (default): save all logs regardless of error presence.
+  # Error log persistence policy (metrics are always reported regardless):
+  #   all     - save every log that contains errors
+  #   sampled - keep at most errorLogSampleN error logs per user per error type per window
+  #   none    - skip all logs that contain errors
+  # When errorLogMode is empty, the deprecated saveErrorLog is used as a
+  # fallback (true -> all, false -> none).
+  errorLogMode: sampled
+  # Max error logs kept per user per error type within each window (sampled mode). Default 1.
+  errorLogSampleN: 1
+  # Sampling window length in seconds (sampled mode). Default 60.
+  errorLogSampleWindowSec: 60
+  # Deprecated: superseded by errorLogMode. Kept for backward compatibility.
   saveErrorLog: false
   # S3/MinIO configuration (required when storageType is "s3")
   s3:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,15 +97,35 @@ type LogS3Config struct {
 	SkipBucketCheck bool   `mapstructure:"skipBucketCheck" yaml:"skipBucketCheck"`
 }
 
+// Error log mode values for LogConfig.ErrorLogMode.
+const (
+	ErrorLogModeAll     = "all"
+	ErrorLogModeSampled = "sampled"
+	ErrorLogModeNone    = "none"
+)
+
 // LogConfig holds logging configuration
 type LogConfig struct {
 	LogFilePath string
 	// StorageType controls where logs are persisted: "disk" (default) or "s3"
 	StorageType string      `mapstructure:"storageType" yaml:"storageType"`
 	S3          LogS3Config `mapstructure:"s3" yaml:"s3"`
-	// SaveErrorLog controls whether logs with errors should be saved to permanent storage.
-	// When false, logs containing Error entries will be skipped for storage (metrics are still reported).
-	// When true (default), all logs are saved regardless of error presence.
+	// ErrorLogMode controls how logs containing errors are persisted:
+	//   "all"     - save every log with errors
+	//   "sampled" - keep at most ErrorLogSampleN error logs per user per error
+	//               type per window
+	//   "none"    - skip all logs with errors
+	// When empty, the deprecated SaveErrorLog is used as a fallback
+	// (true -> all, false -> none). Metrics are reported regardless of mode.
+	ErrorLogMode string `mapstructure:"errorLogMode" yaml:"errorLogMode"`
+	// ErrorLogSampleN is the max error logs kept per user per error type within
+	// each sampling window (sampled mode only). Defaults to 1 when <= 0.
+	ErrorLogSampleN int `mapstructure:"errorLogSampleN" yaml:"errorLogSampleN"`
+	// ErrorLogSampleWindowSec is the sampling window length in seconds
+	// (sampled mode only). Defaults to 60 when <= 0.
+	ErrorLogSampleWindowSec int `mapstructure:"errorLogSampleWindowSec" yaml:"errorLogSampleWindowSec"`
+	// Deprecated: superseded by ErrorLogMode. Retained as a fallback when
+	// ErrorLogMode is empty (true -> all, false -> none).
 	SaveErrorLog bool `mapstructure:"saveErrorLog" yaml:"saveErrorLog"`
 	// LogScanIntervalSec   int
 	// ClassifyModel        string

--- a/internal/config/error_log_mode_test.go
+++ b/internal/config/error_log_mode_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestResolveErrorLogMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         string
+		saveErrorLog bool
+		want         string
+	}{
+		{"explicit all", "all", false, "all"},
+		{"explicit sampled", "sampled", false, "sampled"},
+		{"explicit none", "none", true, "none"},
+		{"trims and lowercases", "  Sampled ", false, "sampled"},
+		{"uppercase", "ALL", false, "all"},
+		{"empty falls back to true->all", "", true, "all"},
+		{"empty falls back to false->none", "", false, "none"},
+		{"invalid falls back to true->all", "bogus", true, "all"},
+		{"invalid falls back to false->none", "bogus", false, "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := LogConfig{ErrorLogMode: tt.mode, SaveErrorLog: tt.saveErrorLog}
+			if got := c.ResolveErrorLogMode(); got != tt.want {
+				t.Errorf("ResolveErrorLogMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorLogSamplingEnabled(t *testing.T) {
+	if !(LogConfig{ErrorLogMode: "sampled"}).ErrorLogSamplingEnabled() {
+		t.Error("expected sampling enabled for sampled mode")
+	}
+	if (LogConfig{ErrorLogMode: "all"}).ErrorLogSamplingEnabled() {
+		t.Error("expected sampling disabled for all mode")
+	}
+	if (LogConfig{ErrorLogMode: "", SaveErrorLog: true}).ErrorLogSamplingEnabled() {
+		t.Error("expected sampling disabled for fallback all")
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 	"github.com/zgsm-ai/chat-rag/internal/logger"
@@ -171,4 +172,33 @@ func ApplyRouterDefaults(c *Config) {
 			logger.Info("priority router retryIntervalMs not set, using default", zap.Int("retryIntervalMs", c.Router.Priority.RetryIntervalMs))
 		}
 	}
+}
+
+// ResolveErrorLogMode normalizes the configured error log mode. The value is
+// trimmed and lowercased first. An explicit valid value wins; an empty value
+// falls back to the deprecated SaveErrorLog (true -> all, false -> none); an
+// unrecognized value logs a warning and uses the same SaveErrorLog fallback.
+func (c LogConfig) ResolveErrorLogMode() string {
+	switch strings.ToLower(strings.TrimSpace(c.ErrorLogMode)) {
+	case ErrorLogModeAll:
+		return ErrorLogModeAll
+	case ErrorLogModeSampled:
+		return ErrorLogModeSampled
+	case ErrorLogModeNone:
+		return ErrorLogModeNone
+	case "":
+		// fall through to the SaveErrorLog fallback below
+	default:
+		logger.Warn("invalid errorLogMode, falling back to saveErrorLog",
+			zap.String("errorLogMode", c.ErrorLogMode))
+	}
+	if c.SaveErrorLog {
+		return ErrorLogModeAll
+	}
+	return ErrorLogModeNone
+}
+
+// ErrorLogSamplingEnabled reports whether the resolved mode is sampled.
+func (c LogConfig) ErrorLogSamplingEnabled() bool {
+	return c.ResolveErrorLogMode() == ErrorLogModeSampled
 }

--- a/internal/service/error_log_sampler.go
+++ b/internal/service/error_log_sampler.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"sync"
+	"time"
+)
+
+// ErrorLogSampler bounds how many error logs are persisted per (user, error type)
+// within each fixed time window. It is safe for concurrent use. Counters live in
+// memory and are per-instance. The window is aligned globally as
+// unixSeconds / windowSec; when the window number changes the whole counter map
+// is dropped, which both aligns windows and bounds memory (no cross-window growth).
+type ErrorLogSampler struct {
+	maxPerWindow int
+	windowSec    int64
+	now          func() time.Time
+
+	mu       sync.Mutex
+	windowID int64
+	counts   map[string]int
+}
+
+// NewErrorLogSampler creates a sampler that keeps at most maxPerWindow entries
+// per (user, error type) within each window of windowSec seconds. A non-positive
+// windowSec is clamped to 1 second.
+func NewErrorLogSampler(maxPerWindow int, windowSec int64) *ErrorLogSampler {
+	if windowSec <= 0 {
+		windowSec = 1
+	}
+	if maxPerWindow <= 0 {
+		maxPerWindow = 1
+	}
+	return &ErrorLogSampler{
+		maxPerWindow: maxPerWindow,
+		windowSec:    windowSec,
+		now:          time.Now,
+		windowID:     -1,
+		counts:       make(map[string]int),
+	}
+}
+
+// Allow reports whether an error log for the given user and error type may be
+// saved in the current window. When it returns true, the call is counted.
+func (s *ErrorLogSampler) Allow(user, errorType string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	wid := s.now().Unix() / s.windowSec
+	if wid != s.windowID {
+		s.windowID = wid
+		s.counts = make(map[string]int)
+	}
+
+	key := user + "\x00" + errorType
+	if s.counts[key] >= s.maxPerWindow {
+		return false
+	}
+	s.counts[key]++
+	return true
+}

--- a/internal/service/error_log_sampler_test.go
+++ b/internal/service/error_log_sampler_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestErrorLogSampler_AllowsUnderLimit(t *testing.T) {
+	s := NewErrorLogSampler(3, 60)
+	for i := 0; i < 3; i++ {
+		if !s.Allow("alice", "ApiError") {
+			t.Fatalf("call %d: expected allow", i+1)
+		}
+	}
+}
+
+func TestErrorLogSampler_DeniesOverLimit(t *testing.T) {
+	s := NewErrorLogSampler(1, 60)
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected first allow")
+	}
+	if s.Allow("alice", "ApiError") {
+		t.Fatal("expected deny after limit reached")
+	}
+}
+
+func TestErrorLogSampler_ResetsAfterWindow(t *testing.T) {
+	s := NewErrorLogSampler(1, 60)
+	base := time.Unix(1_000_000_020, 0) // aligned to a 60s window boundary
+	s.now = func() time.Time { return base }
+
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected first allow")
+	}
+	if s.Allow("alice", "ApiError") {
+		t.Fatal("expected deny within window")
+	}
+
+	// Still inside the same window at +59s.
+	s.now = func() time.Time { return base.Add(59 * time.Second) }
+	if s.Allow("alice", "ApiError") {
+		t.Fatal("expected deny at +59s (same window)")
+	}
+
+	// New window at +60s.
+	s.now = func() time.Time { return base.Add(60 * time.Second) }
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected allow after window reset at +60s")
+	}
+}
+
+func TestErrorLogSampler_UsersAreIsolated(t *testing.T) {
+	s := NewErrorLogSampler(1, 60)
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected allow for alice")
+	}
+	if !s.Allow("bob", "ApiError") {
+		t.Fatal("expected allow for bob (separate user bucket)")
+	}
+	if s.Allow("alice", "ApiError") {
+		t.Fatal("expected alice bucket to be exhausted")
+	}
+}
+
+func TestErrorLogSampler_TypesAreIsolated(t *testing.T) {
+	s := NewErrorLogSampler(1, 60)
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected allow for ApiError")
+	}
+	if !s.Allow("alice", "ServerError") {
+		t.Fatal("expected allow for ServerError (separate type bucket)")
+	}
+	if s.Allow("alice", "ApiError") {
+		t.Fatal("expected ApiError bucket to be exhausted")
+	}
+}
+
+func TestErrorLogSampler_NonPositiveWindowDoesNotPanic(t *testing.T) {
+	s := NewErrorLogSampler(1, 0)
+	if !s.Allow("alice", "ApiError") {
+		t.Fatal("expected allow with defensive window")
+	}
+}

--- a/internal/service/log_record.go
+++ b/internal/service/log_record.go
@@ -77,8 +77,11 @@ type LoggerRecordService struct {
 	deptClient     client.DepartmentInterface
 	instanceID     string
 	// enableClassification bool
-	// saveErrorLog controls whether logs with errors are saved to permanent storage
-	saveErrorLog bool
+	// errorLogMode controls how logs with errors are persisted: "all", "sampled", or "none".
+	errorLogMode string
+	// errorSampler bounds how many error logs are saved per user per error type per
+	// window; non-nil only when errorLogMode is "sampled".
+	errorSampler *ErrorLogSampler
 
 	logChan         chan *model.ChatLog
 	stopChan        chan struct{}
@@ -91,38 +94,49 @@ type LoggerRecordService struct {
 
 const metricsLocalLogPathMaxBytes = 128
 
-// NewLogRecordService creates a new logger service
-func NewLogRecordService(config config.Config) LogRecordInterface {
-	// Create temp directory under logFilePath for temporary log files
-	// tempLogDir := filepath.Join(config.Log.LogFilePath, "temp") // No longer needed
+const (
+	defaultErrorLogSampleN         = 1
+	defaultErrorLogSampleWindowSec = 60
+)
 
+// NewLogRecordService creates a new logger service
+func NewLogRecordService(cfg config.Config) LogRecordInterface {
 	instanceID := os.Getenv("HOSTNAME")
 	if instanceID == "" {
 		instanceID = fmt.Sprintf("instance-%d", rand.Intn(10000))
 	}
 
 	var deptClient client.DepartmentInterface
-	if config.DepartmentApiEndpoint != "" {
-		deptClient = client.NewDepartmentClient(config.DepartmentApiEndpoint)
+	if cfg.DepartmentApiEndpoint != "" {
+		deptClient = client.NewDepartmentClient(cfg.DepartmentApiEndpoint)
 	}
 	var metricsReporter *ChatMetricsReporter = nil
-	if config.ChatMetrics.Enabled {
-		metricsReporter = NewChatMetricsReporter(config.ChatMetrics.Url, config.ChatMetrics.Method)
+	if cfg.ChatMetrics.Enabled {
+		metricsReporter = NewChatMetricsReporter(cfg.ChatMetrics.Url, cfg.ChatMetrics.Method)
+	}
+
+	errorLogMode := cfg.Log.ResolveErrorLogMode()
+	var errorSampler *ErrorLogSampler
+	if errorLogMode == config.ErrorLogModeSampled {
+		n := cfg.Log.ErrorLogSampleN
+		if n <= 0 {
+			n = defaultErrorLogSampleN
+		}
+		windowSec := cfg.Log.ErrorLogSampleWindowSec
+		if windowSec <= 0 {
+			windowSec = defaultErrorLogSampleWindowSec
+		}
+		errorSampler = NewErrorLogSampler(n, int64(windowSec))
 	}
 
 	return &LoggerRecordService{
-		// tempLogFilePath:      tempLogDir,             // Temporary logs directory - no longer needed
-		// scanInterval:         time.Duration(config.Log.LogScanIntervalSec) * time.Second,
-		// llmConfig:            config.LLM,
-		// classifyModel:        config.Log.ClassifyModel,
-		// enableClassification: config.Log.EnableClassification,
-
-		logFilePath:     config.Log.LogFilePath, // Permanent storage directory
-		saveErrorLog:    config.Log.SaveErrorLog,
-		logChan:         make(chan *model.ChatLog, 1000),
-		stopChan:        make(chan struct{}),
-		instanceID:      instanceID,
-		deptClient:      deptClient,
+		logFilePath:  cfg.Log.LogFilePath, // Permanent storage directory
+		errorLogMode: errorLogMode,
+		errorSampler: errorSampler,
+		logChan:      make(chan *model.ChatLog, 1000),
+		stopChan:     make(chan struct{}),
+		instanceID:   instanceID,
+		deptClient:   deptClient,
 		metricsReporter: metricsReporter,
 	}
 }
@@ -313,6 +327,37 @@ func (ls *LoggerRecordService) logSync(logs *model.ChatLog) {
 }
 */
 
+// shouldSaveErrorLog decides whether a log carrying errors should be persisted.
+// It must only be called when len(logs.Error) > 0.
+func (ls *LoggerRecordService) shouldSaveErrorLog(logs *model.ChatLog) bool {
+	switch ls.errorLogMode {
+	case config.ErrorLogModeAll:
+		return true
+	case config.ErrorLogModeSampled:
+		if ls.errorSampler == nil {
+			return true // fail-open: never silently drop when misconfigured
+		}
+		// Use the same sanitized identity the archive path uses, so an empty
+		// user name buckets under "unknown" consistently with the on-disk layout.
+		userKey := ls.sanitizeFilename(logs.Identity.UserName, "unknown")
+		return ls.errorSampler.Allow(userKey, firstErrorTypeKey(logs))
+	default: // "none" or any unexpected value
+		return false
+	}
+}
+
+// firstErrorTypeKey returns the error type of the first error entry as a string,
+// matching how metrics extract the reported error code.
+func firstErrorTypeKey(logs *model.ChatLog) string {
+	if len(logs.Error) == 0 {
+		return ""
+	}
+	for k := range logs.Error[0] {
+		return string(k)
+	}
+	return ""
+}
+
 // logDirectToStorage processes and writes a log entry directly to permanent storage
 func (ls *LoggerRecordService) logDirectToStorage(logs *model.ChatLog) {
 	ls.mu.Lock()
@@ -332,12 +377,14 @@ func (ls *LoggerRecordService) logDirectToStorage(logs *model.ChatLog) {
 	}
 
 	// Decide whether to save to permanent storage.
-	// When the log contains errors and saveErrorLog is false, skip saving.
+	// When the log contains errors, delegate to the mode-sensitive shouldSaveErrorLog.
 	var writeInfo *storage.WriteInfo
-	if len(logs.Error) > 0 && !ls.saveErrorLog {
-		logger.Info("Skipping log save.",
+	if len(logs.Error) > 0 && !ls.shouldSaveErrorLog(logs) {
+		logger.Info("Skipping error log save.",
 			zap.String("request_id", logs.Identity.RequestID),
+			zap.String("user", logs.Identity.UserName),
 			zap.Int("error_count", len(logs.Error)),
+			zap.String("error_log_mode", ls.errorLogMode),
 		)
 	} else {
 		writeInfo = ls.saveLogToPermanentStorage(logs)

--- a/internal/service/log_record.go
+++ b/internal/service/log_record.go
@@ -130,13 +130,13 @@ func NewLogRecordService(cfg config.Config) LogRecordInterface {
 	}
 
 	return &LoggerRecordService{
-		logFilePath:  cfg.Log.LogFilePath, // Permanent storage directory
-		errorLogMode: errorLogMode,
-		errorSampler: errorSampler,
-		logChan:      make(chan *model.ChatLog, 1000),
-		stopChan:     make(chan struct{}),
-		instanceID:   instanceID,
-		deptClient:   deptClient,
+		logFilePath:     cfg.Log.LogFilePath, // Permanent storage directory
+		errorLogMode:    errorLogMode,
+		errorSampler:    errorSampler,
+		logChan:         make(chan *model.ChatLog, 1000),
+		stopChan:        make(chan struct{}),
+		instanceID:      instanceID,
+		deptClient:      deptClient,
 		metricsReporter: metricsReporter,
 	}
 }

--- a/internal/service/log_record_test.go
+++ b/internal/service/log_record_test.go
@@ -3,8 +3,10 @@ package service
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zgsm-ai/chat-rag/internal/config"
 	"github.com/zgsm-ai/chat-rag/internal/model"
+	"github.com/zgsm-ai/chat-rag/internal/storage"
 	"github.com/zgsm-ai/chat-rag/internal/types"
 )
 
@@ -242,5 +244,65 @@ func TestShouldSaveErrorLog_DifferentErrorTypesIndependentBuckets(t *testing.T) 
 	// Second call with ApiError: denied (same bucket exhausted).
 	if ls.shouldSaveErrorLog(logApiErr) {
 		t.Fatal("expected second ApiError save for alice to be dropped")
+	}
+}
+
+// --- Invariant: metrics are reported even when the error log is not persisted ---
+
+type fakeMetrics struct{ recordCalls int }
+
+func (f *fakeMetrics) RecordChatLog(*model.ChatLog)      { f.recordCalls++ }
+func (f *fakeMetrics) GetRegistry() *prometheus.Registry { return nil }
+
+type fakeStorage struct{ writes int }
+
+func (f *fakeStorage) Write(key string, data []byte) (*storage.WriteInfo, error) {
+	f.writes++
+	return &storage.WriteInfo{FilePath: key}, nil
+}
+func (f *fakeStorage) Close() error { return nil }
+
+func newErrorLogWithUser(user string) *model.ChatLog {
+	log := newErrorLog(user)
+	log.Identity.UserInfo = &model.UserInfo{}
+	return log
+}
+
+func TestLogDirectToStorage_NoneModeStillReportsMetrics(t *testing.T) {
+	metrics := &fakeMetrics{}
+	store := &fakeStorage{}
+	ls := &LoggerRecordService{errorLogMode: config.ErrorLogModeNone}
+	ls.SetMetricsService(metrics)
+	ls.SetStorageBackend(store)
+
+	ls.logDirectToStorage(newErrorLogWithUser("alice"))
+
+	if metrics.recordCalls != 1 {
+		t.Fatalf("expected RecordChatLog called once even when save skipped, got %d", metrics.recordCalls)
+	}
+	if store.writes != 0 {
+		t.Fatalf("expected no storage write in none mode, got %d", store.writes)
+	}
+}
+
+func TestLogDirectToStorage_SampledReportsMetricsOnDrop(t *testing.T) {
+	metrics := &fakeMetrics{}
+	store := &fakeStorage{}
+	ls := &LoggerRecordService{
+		errorLogMode: config.ErrorLogModeSampled,
+		errorSampler: NewErrorLogSampler(1, 60),
+	}
+	ls.SetMetricsService(metrics)
+	ls.SetStorageBackend(store)
+
+	for i := 0; i < 2; i++ {
+		ls.logDirectToStorage(newErrorLogWithUser("alice"))
+	}
+
+	if metrics.recordCalls != 2 {
+		t.Fatalf("expected RecordChatLog called twice (always reported), got %d", metrics.recordCalls)
+	}
+	if store.writes != 1 {
+		t.Fatalf("expected exactly one storage write (second sampled out), got %d", store.writes)
 	}
 }

--- a/internal/service/log_record_test.go
+++ b/internal/service/log_record_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/zgsm-ai/chat-rag/internal/config"
+	"github.com/zgsm-ai/chat-rag/internal/model"
+	"github.com/zgsm-ai/chat-rag/internal/types"
+)
+
+func newErrorLog(user string) *model.ChatLog {
+	log := &model.ChatLog{
+		Error: []map[types.ErrorType]string{
+			{types.ErrApiError: "boom"},
+		},
+	}
+	log.Identity.UserName = user
+	return log
+}
+
+func TestShouldSaveErrorLog_AllMode(t *testing.T) {
+	ls := &LoggerRecordService{errorLogMode: config.ErrorLogModeAll}
+	if !ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected save in all mode")
+	}
+}
+
+func TestShouldSaveErrorLog_NoneMode(t *testing.T) {
+	ls := &LoggerRecordService{errorLogMode: config.ErrorLogModeNone}
+	if ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected skip in none mode")
+	}
+}
+
+func TestShouldSaveErrorLog_SampledMode(t *testing.T) {
+	ls := &LoggerRecordService{
+		errorLogMode: config.ErrorLogModeSampled,
+		errorSampler: NewErrorLogSampler(1, 60),
+	}
+	if !ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected first sampled save for alice to be allowed")
+	}
+	if ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected second sampled save for alice to be dropped")
+	}
+	if !ls.shouldSaveErrorLog(newErrorLog("bob")) {
+		t.Fatal("expected sampled save for bob (separate user) to be allowed")
+	}
+}
+
+func TestShouldSaveErrorLog_SampledModeNilSampler(t *testing.T) {
+	ls := &LoggerRecordService{errorLogMode: config.ErrorLogModeSampled}
+	if !ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected save when sampler is nil (fail-open)")
+	}
+}
+
+func TestFirstErrorTypeKey(t *testing.T) {
+	if got := firstErrorTypeKey(newErrorLog("alice")); got != string(types.ErrApiError) {
+		t.Errorf("firstErrorTypeKey() = %q, want %q", got, types.ErrApiError)
+	}
+	if got := firstErrorTypeKey(&model.ChatLog{}); got != "" {
+		t.Errorf("firstErrorTypeKey() on empty = %q, want empty", got)
+	}
+	emptyMap := &model.ChatLog{Error: []map[types.ErrorType]string{{}}}
+	if got := firstErrorTypeKey(emptyMap); got != "" {
+		t.Errorf("firstErrorTypeKey() on empty map = %q, want empty", got)
+	}
+}

--- a/internal/service/log_record_test.go
+++ b/internal/service/log_record_test.go
@@ -67,3 +67,180 @@ func TestFirstErrorTypeKey(t *testing.T) {
 		t.Errorf("firstErrorTypeKey() on empty map = %q, want empty", got)
 	}
 }
+
+// --- Integration tests: full wiring from config.Config → NewLogRecordService → shouldSaveErrorLog ---
+
+func TestNewLogRecordService_Integration_ErrorLogModeAll(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Log.ErrorLogMode = config.ErrorLogModeAll
+
+	svc := NewLogRecordService(cfg)
+	ls, ok := svc.(*LoggerRecordService)
+	if !ok {
+		t.Fatal("NewLogRecordService did not return *LoggerRecordService")
+	}
+
+	if ls.errorLogMode != config.ErrorLogModeAll {
+		t.Errorf("errorLogMode = %q, want %q", ls.errorLogMode, config.ErrorLogModeAll)
+	}
+	if ls.errorSampler != nil {
+		t.Error("errorSampler should be nil in all mode")
+	}
+	if !ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected save in all mode via integration path")
+	}
+}
+
+func TestNewLogRecordService_Integration_ErrorLogModeNone(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Log.ErrorLogMode = config.ErrorLogModeNone
+
+	svc := NewLogRecordService(cfg)
+	ls, ok := svc.(*LoggerRecordService)
+	if !ok {
+		t.Fatal("NewLogRecordService did not return *LoggerRecordService")
+	}
+
+	if ls.errorLogMode != config.ErrorLogModeNone {
+		t.Errorf("errorLogMode = %q, want %q", ls.errorLogMode, config.ErrorLogModeNone)
+	}
+	if ls.errorSampler != nil {
+		t.Error("errorSampler should be nil in none mode")
+	}
+	if ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected skip in none mode via integration path")
+	}
+}
+
+func TestNewLogRecordService_Integration_ErrorLogModeSampled(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Log.ErrorLogMode = config.ErrorLogModeSampled
+
+	svc := NewLogRecordService(cfg)
+	ls, ok := svc.(*LoggerRecordService)
+	if !ok {
+		t.Fatal("NewLogRecordService did not return *LoggerRecordService")
+	}
+
+	if ls.errorLogMode != config.ErrorLogModeSampled {
+		t.Errorf("errorLogMode = %q, want %q", ls.errorLogMode, config.ErrorLogModeSampled)
+	}
+	if ls.errorSampler == nil {
+		t.Fatal("errorSampler should not be nil in sampled mode")
+	}
+
+	// Verify the sampler actually limits: first call allowed, second denied.
+	if !ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected first sampled save for alice to be allowed")
+	}
+	if ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected second sampled save for alice to be dropped")
+	}
+	// Different user should still be allowed.
+	if !ls.shouldSaveErrorLog(newErrorLog("bob")) {
+		t.Fatal("expected sampled save for bob (separate user) to be allowed")
+	}
+}
+
+func TestNewLogRecordService_Integration_SamplerDefaultsApplied(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Log.ErrorLogMode = config.ErrorLogModeSampled
+	// Leave ErrorLogSampleN and ErrorLogSampleWindowSec at zero to exercise defaults.
+
+	svc := NewLogRecordService(cfg)
+	ls, ok := svc.(*LoggerRecordService)
+	if !ok {
+		t.Fatal("NewLogRecordService did not return *LoggerRecordService")
+	}
+
+	if ls.errorSampler == nil {
+		t.Fatal("errorSampler should not be nil when defaults are applied")
+	}
+	if ls.errorSampler.maxPerWindow != 1 {
+		t.Errorf("default maxPerWindow = %d, want 1", ls.errorSampler.maxPerWindow)
+	}
+	if ls.errorSampler.windowSec != 60 {
+		t.Errorf("default windowSec = %d, want 60", ls.errorSampler.windowSec)
+	}
+}
+
+func TestNewLogRecordService_Integration_EmptyUserNameFallback(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Log.ErrorLogMode = config.ErrorLogModeSampled
+
+	svc := NewLogRecordService(cfg)
+	ls, ok := svc.(*LoggerRecordService)
+	if !ok {
+		t.Fatal("NewLogRecordService did not return *LoggerRecordService")
+	}
+
+	// Log with empty UserName: shouldSaveErrorLog must use "unknown" fallback
+	// via sanitizeFilename, and the first call must be allowed.
+	log := newErrorLog("")
+	if !ls.shouldSaveErrorLog(log) {
+		t.Fatal("expected save for empty username (fallback to 'unknown')")
+	}
+	// Second call with same empty user should be denied (N=1 window).
+	if ls.shouldSaveErrorLog(log) {
+		t.Fatal("expected second empty-username call to be dropped")
+	}
+	// A different error type for the same empty user should still be allowed
+	// (separate type bucket).
+	logDiffType := &model.ChatLog{
+		Error: []map[types.ErrorType]string{
+			{types.ErrServerError: "internal error"},
+		},
+	}
+	logDiffType.Identity.UserName = ""
+	if !ls.shouldSaveErrorLog(logDiffType) {
+		t.Fatal("expected save for empty username with different error type")
+	}
+}
+
+// --- Regression tests ---
+
+func TestShouldSaveErrorLog_UnknownMode(t *testing.T) {
+	// When errorLogMode is set to an unrecognized value (neither "all",
+	// "sampled", nor "none"), the default case in shouldSaveErrorLog must
+	// deny the save — fail closed, not open.
+	ls := &LoggerRecordService{errorLogMode: "bogus"}
+	if ls.shouldSaveErrorLog(newErrorLog("alice")) {
+		t.Fatal("expected deny for unknown errorLogMode (fail-closed)")
+	}
+}
+
+func TestShouldSaveErrorLog_DifferentErrorTypesIndependentBuckets(t *testing.T) {
+	// Per-user-per-type sampling: different error types for the same user
+	// are tracked in separate buckets, so each type gets its own allowance.
+	ls := &LoggerRecordService{
+		errorLogMode: config.ErrorLogModeSampled,
+		errorSampler: NewErrorLogSampler(1, 60),
+	}
+
+	logApiErr := &model.ChatLog{
+		Error: []map[types.ErrorType]string{
+			{types.ErrApiError: "api failure"},
+		},
+	}
+	logApiErr.Identity.UserName = "alice"
+
+	logServerErr := &model.ChatLog{
+		Error: []map[types.ErrorType]string{
+			{types.ErrServerError: "internal failure"},
+		},
+	}
+	logServerErr.Identity.UserName = "alice"
+
+	// First call with ApiError: allowed.
+	if !ls.shouldSaveErrorLog(logApiErr) {
+		t.Fatal("expected first ApiError save for alice to be allowed")
+	}
+	// First call with ServerError (different type): still allowed.
+	if !ls.shouldSaveErrorLog(logServerErr) {
+		t.Fatal("expected first ServerError save for alice to be allowed")
+	}
+	// Second call with ApiError: denied (same bucket exhausted).
+	if ls.shouldSaveErrorLog(logApiErr) {
+		t.Fatal("expected second ApiError save for alice to be dropped")
+	}
+}


### PR DESCRIPTION
# 错误日志采样方案

## 一、背景与问题

chat-rag 会把每个请求的请求体(prompt + 参数)记录进 `ChatLog` 落盘,用于排查。
是否保存"带错误"的日志,目前由一个布尔开关 `Log.saveErrorLog` 控制:

- `true` → 所有错误日志都存
- `false` → 错误日志一律不存(指标仍照常上报)

现网配置为 `false`。原因是有**高频错误会打爆磁盘**，例如:

1. 用户配额耗尽(请求量大、排查价值低)
2. 上游模型 `429` 风暴(瞬时爆发、影响所有用户)

但 `false` 把请求体也一起丢了。于是当出现**真正需要排查的错误**时——例如上游返回 `400`、根因就在请求体本身(客户端漏传字段)——现场已经没有请求体可看了。

> 真实案例:上游报 `400`,提示 `The reasoning_content in the thinking mode must be passed back to the API`。根因在请求体里,但日志没存,无法定位是哪条请求、哪个字段的问题。

**核心矛盾:** 全存会被高频错误打爆磁盘;全不存又丢失了排查所需的请求体。

## 二、方案概述

把"全存 / 全不存"的二选一,升级为三种**错误日志模式(Error Log Mode)**,并新增一种**采样**模式作为现网默认:

| 模式 | 行为 |
|------|------|
| `all` | 所有错误日志都存(等价于旧 `saveErrorLog: true`) |
| `none` | 错误日志一律不存(等价于旧 `saveErrorLog: false`) |
| `sampled` | **按用户 + 错误类型限量保存**:每个用户的每种错误类型在每个时间窗内最多存 N 条,超出的丢弃 |

非错误日志不受影响,始终全量保存;无论哪种模式,**指标都照常上报**。

### 采样的粒度

按**用户(UserName)+ 错误类型 + 时间窗**限量,每(用户,类型)每窗最多 N 条,默认 **N=1**。

为什么把用户放进键里(而不是只按错误类型):

- 实际排查方式是**事后直接去现网按用户捞**错误日志,无法预先指定要查谁,所以"任意用户的错误都得已经留在盘上"。
- 只按错误类型切时,一个吵闹用户或一场风暴会占满该类型的名额,导致**你要查的那个安静用户那一条被挤掉**。把用户放进键里,每个用户有自己的桶,互不挤占。
- 单用户配额狂刷被**按用户封顶**(N=1 时一个用户每类型每窗只留 1 条),这正好解决了最初"单用户错误请求打爆磁盘"的主例。

不额外加全局上限:N=1 已把每用户贡献压到下限;正常时同时出错的用户本就不多。粗粒度错误类型(`ApiError`/`ServerError`/`ContextExceeded`)保持不变——按用户切后,上游 `429` 与罕见 `400` 同属 `ApiError` 也基本不会互相挤(同一用户很少同窗既狂刷 429 又来一条稀有 400)。

> 残余风险(已知并接受):极端跨用户风暴(上游全挂、同分钟大量不同用户出错)时,落盘量 ≈ 同时出错的不同用户数 × 错误类型数 × N。在现网"同时出错用户数可控"的前提下安全;若日后规模变大,可再加每类型全局上限兜底(本期不做)。

## 三、配置

放在 `etc/chat-api.yaml` 的 `Log` 块下,与现有配置并列:

```yaml
Log:
  # 错误日志模式:all=全存 / sampled=采样 / none=全不存
  errorLogMode: sampled
  # 采样模式下:每个用户的每种错误类型在每个时间窗内最多保存的条数
  errorLogSampleN: 1
  # 采样时间窗长度(秒)
  errorLogSampleWindowSec: 60
```

**默认值:** `errorLogSampleN=1`、`errorLogSampleWindowSec=60`。

**向后兼容:** 当 `errorLogMode` 未配置时,自动回落读旧的 `saveErrorLog`(`true → all`,`false → none`),**现网现有行为保持不变**;运维想启用采样,显式把配置改成 `errorLogMode: sampled` 即可。旧的 `saveErrorLog` 标记为 deprecated。

**生效方式:** `Log` 配置在服务启动时一次性读入(不走 Nacos 热更),**改配置需重启 / 滚动重启 Pod**——与现在的 `saveErrorLog` 完全一致。

## 四、行为说明

- **计数器为每实例内存计数**,不依赖 Redis。采用"全局窗口号 reset"的固定窗实现:窗口号 = `当前秒 / 窗长`,窗口号一变就整体清空计数 map——既是真正对齐的固定窗,又天然每窗自动清理,内存不跨窗累积。
- 采样键 = `UserName` + 错误类型。一条日志若同时挂多个错误,类型取第一个错误(与现有指标上报口径一致);`UserName` 经与落盘归档同一套 `sanitizeFilename(…, "unknown")` 归一,空用户名统一归到 `unknown` 桶,与磁盘目录口径一致。
- 被采样命中的错误日志,**保存完整的 `ChatLog`**(请求体 + 错误 + tokens / 延迟 / 降级追踪等),与成功日志同构,不做裁剪。

## 五、效果

| 场景 | 改造前(`saveErrorLog: false`) | 改造后(`sampled`, N=1) |
|------|------------------------------|---------------------|
| 上游 400(根因在请求体) | 整条丢弃,无从排查 | 该用户该窗留 1 条,可拿到请求体 |
| 单用户配额耗尽狂刷 | 不存(磁盘安全) | 该用户该窗封顶 1 条,磁盘安全 |
| 想事后捞某安静用户的错误 | 整条丢弃 | 每个用户独立成桶,不被别人挤掉 |
| 跨用户大风暴 | 不存(磁盘安全) | 每用户仅 1 条;量 ≈ 出错用户数,现网量级可控 |

## 六、范围

- **只改 `ChatLog` 主链路**(`internal/service/log_record.go` 的落盘判定)。
- **不动** `forward_handler.go` 的转发日志链路(独立的 `forward_log.go`,不在本次范围)。
- **不改**指标上报逻辑——无论是否落盘,指标都照常上报。
- 配置示例同步到 `etc/chat-api.yaml` 与 `README` 的 Log 说明。`deploy/dev.yaml` 为扁平旧 schema(与当前嵌套 `Config.Log` 不符),本次不改;上线前由部署负责人在真实 ConfigMap 的嵌套 `Log:` 下补 `errorLogMode` 三件套。


